### PR TITLE
ハンバーガーメニューにトップリンク追加・ヘッダー幅統一

### DIFF
--- a/application/frontend/client/component/molecules/Header.tsx
+++ b/application/frontend/client/component/molecules/Header.tsx
@@ -4,6 +4,7 @@ import { Box } from "@chakra-ui/react";
 import { RxHamburgerMenu, RxCross1 } from "react-icons/rx";
 import Link from "next/link";
 import { STYLE_COLOR } from "@/const/style/STYLE_COLOR";
+import { STYLE } from "@/const/common/STYLE";
 import { COMMON } from "@/const/common/COMMON";
 import { NAV_ITEMS } from "@/const/common/NAV_ITEMS";
 import { getLatestPeriod } from "@/const/function/getLatestPeriod";
@@ -70,29 +71,36 @@ export default function Header() {
     <>
       <Box
         as="header"
-        display={"flex"}
+        position={"fixed"}
         width={"100%"}
         top={0}
-        alignItems={"center"}
-        justifyContent={"space-between"}
         height={"60px"}
         zIndex={5}
         bg={STYLE_COLOR.MAIN}
         color={STYLE_COLOR.PRIMARY}
         fontSize={"16px"}
-        px={6}
       >
-        <Link href="/">{COMMON.SITE_NAME}</Link>
         <Box
-          as="button"
-          onClick={() => setIsOpen(!isOpen)}
-          cursor={"pointer"}
           display={"flex"}
           alignItems={"center"}
-          justifyContent={"center"}
-          aria-label={isOpen ? "メニューを閉じる" : "メニューを開く"}
+          justifyContent={"space-between"}
+          maxW={STYLE.WIDTH.SECTION}
+          mx={"auto"}
+          px={6}
+          height={"100%"}
         >
-          {isOpen ? <RxCross1 size={24} /> : <RxHamburgerMenu size={24} />}
+          <Link href="/">{COMMON.SITE_NAME}</Link>
+          <Box
+            as="button"
+            onClick={() => setIsOpen(!isOpen)}
+            cursor={"pointer"}
+            display={"flex"}
+            alignItems={"center"}
+            justifyContent={"center"}
+            aria-label={isOpen ? "メニューを閉じる" : "メニューを開く"}
+          >
+            {isOpen ? <RxCross1 size={24} /> : <RxHamburgerMenu size={24} />}
+          </Box>
         </Box>
       </Box>
       {isOpen && (

--- a/application/frontend/client/const/common/NAV_ITEMS.tsx
+++ b/application/frontend/client/const/common/NAV_ITEMS.tsx
@@ -2,6 +2,7 @@ import { PATH } from "@/const/common/PATH";
 
 export const NAV_ITEMS = (period: string) =>
   [
+    { label: "トップ", href: PATH.URL.HOME },
     { label: "レギュレーション一覧", href: "/period" },
     { label: "現在のレギュレーション", href: `/${period}` },
     { label: "ハウスルール", href: PATH.URL.HOUSE_RULE.ROOT },


### PR DESCRIPTION
## Summary
- ハンバーガーメニューのメニューリスト最上部に「トップ」リンク（`/`）を追加
- ヘッダー内部コンテンツの幅を他セクションと同じ `STYLE.WIDTH.SECTION`（600px）に統一
- ヘッダー自体は横幅100%を維持しつつ、内部要素を中央寄せ

## Issue
Close #12

## Test plan
- [ ] ハンバーガーメニューを開き、最上部に「トップ」リンクが表示されることを確認
- [ ] 「トップ」リンクをクリックしてトップページに遷移することを確認
- [ ] ヘッダーの内部コンテンツ幅が他セクションと揃っていることを確認
- [ ] ヘッダー背景色が横幅100%で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)