### PR TITLE
E-27 FormRecord に (string | number)[] を追加して型エラーを解消

### DIFF
--- a/application/frontend/admin/const/type/config/EntityConfigType.ts
+++ b/application/frontend/admin/const/type/config/EntityConfigType.ts
@@ -1,7 +1,7 @@
 import type { TableColumnType, TableRow } from "@/const/type/table/TableColumnType";
 import type { FormItemType } from "@/const/type/form/FormItemType";
 
-export type FormRecord = Record<string, string | number | boolean | string[] | number[] | null>;
+export type FormRecord = Record<string, string | number | boolean | string[] | number[] | (string | number)[] | null>;
 
 export type EntityConfigType = {
   apiType: string;


### PR DESCRIPTION
## Summary

- `CheckboxGroupField` の `onChange` が返す `(string | number)[]` が `FormRecord` の型に合わずデプロイ時に型エラーが発生していた
- `FormRecord` に `(string | number)[]` を追加して解消

## Test plan

- [ ] デプロイ時の型エラーが解消されること
- [ ] チェックボックスグループ（種族タイプ・使用可能神格等）が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)