### PR TITLE
E-29 レギュレーション取得を公開状態のものに限定する

### DIFF
--- a/application/frontend/client/const/function/getGodItems.ts
+++ b/application/frontend/client/const/function/getGodItems.ts
@@ -1,6 +1,7 @@
 import { supabase } from "@/lib/supabase";
 import type { GodItemType } from "@/const/type/god/GodItemType";
 import { getItemRegulationIds } from "@/const/function/getItemRegulations";
+import { isPublicRegulation } from "@/const/function/isPublicRegulation";
 
 export async function getGodItems(type: "period", id: string): Promise<GodItemType[]>;
 export async function getGodItems(type: "all"): Promise<GodItemType[]>;
@@ -23,6 +24,8 @@ export async function getGodItems(
   }));
 
   if (type === "period") {
+    const isPublic = await isPublicRegulation(Number(id!));
+    if (!isPublic) return [];
     const allowedIds = await getItemRegulationIds("god", Number(id!));
     return items.filter((item) => item.isAlways || allowedIds.has(item.id));
   }

--- a/application/frontend/client/const/function/getRaceItems.ts
+++ b/application/frontend/client/const/function/getRaceItems.ts
@@ -1,6 +1,7 @@
 import { supabase } from "@/lib/supabase";
 import type { RaceItemType } from "@/const/type/race/RaceItemType";
 import { getItemRegulationIds } from "@/const/function/getItemRegulations";
+import { isPublicRegulation } from "@/const/function/isPublicRegulation";
 
 export async function getRaceItems(type: "period", id: string): Promise<RaceItemType[]>;
 export async function getRaceItems(type: "all"): Promise<RaceItemType[]>;
@@ -23,6 +24,8 @@ export async function getRaceItems(
   }));
 
   if (type === "period") {
+    const isPublic = await isPublicRegulation(Number(id!));
+    if (!isPublic) return [];
     const allowedIds = await getItemRegulationIds("race", Number(id!));
     return items.filter((item) => item.isAlways || allowedIds.has(item.id));
   }

--- a/application/frontend/client/const/function/getRegulationItems.ts
+++ b/application/frontend/client/const/function/getRegulationItems.ts
@@ -10,6 +10,7 @@ const fetchRegulationRows = async (): Promise<RegulationRow[]> => {
   const { data, error } = await supabase
     .from("regulation_items")
     .select("id, name, description, recruitment, stage, race, supplement, notes, level_cap_belt")
+    .eq("publish_type", "public")
     .order("id", { ascending: true });
   if (error) throw error;
 

--- a/application/frontend/client/const/function/getSchoolItems.ts
+++ b/application/frontend/client/const/function/getSchoolItems.ts
@@ -1,6 +1,7 @@
 import { supabase } from "@/lib/supabase";
 import type { SchoolItemType } from "@/const/type/school/SchoolItemType";
 import { getItemRegulationIds } from "@/const/function/getItemRegulations";
+import { isPublicRegulation } from "@/const/function/isPublicRegulation";
 
 export async function getSchoolItems(type: "period", id: string): Promise<SchoolItemType[]>;
 export async function getSchoolItems(type: "all"): Promise<SchoolItemType[]>;
@@ -23,6 +24,8 @@ export async function getSchoolItems(
   }));
 
   if (type === "period") {
+    const isPublic = await isPublicRegulation(Number(id!));
+    if (!isPublic) return [];
     const allowedIds = await getItemRegulationIds("school", Number(id!));
     return items.filter((item) => item.isAlways || allowedIds.has(item.id));
   }

--- a/application/frontend/client/const/function/getSupplementItems.ts
+++ b/application/frontend/client/const/function/getSupplementItems.ts
@@ -1,6 +1,7 @@
 import { supabase } from "@/lib/supabase";
 import type { SupplementItemType } from "@/const/type/supplement/SupplementItemType";
 import { getItemRegulationIds } from "@/const/function/getItemRegulations";
+import { isPublicRegulation } from "@/const/function/isPublicRegulation";
 
 export async function getSupplementItems(type: "period", id: string): Promise<SupplementItemType[]>;
 export async function getSupplementItems(type: "all"): Promise<SupplementItemType[]>;
@@ -22,6 +23,8 @@ export async function getSupplementItems(
   }));
 
   if (type === "period") {
+    const isPublic = await isPublicRegulation(Number(id!));
+    if (!isPublic) return [];
     const allowedIds = await getItemRegulationIds("supplement", Number(id!));
     return items.filter((item) => item.isAlways || allowedIds.has(item.id));
   }

--- a/application/frontend/client/const/function/isPublicRegulation.ts
+++ b/application/frontend/client/const/function/isPublicRegulation.ts
@@ -1,0 +1,11 @@
+import { supabase } from "@/lib/supabase";
+
+export async function isPublicRegulation(id: number): Promise<boolean> {
+  const { data } = await supabase
+    .from("regulation_items")
+    .select("id")
+    .eq("id", id)
+    .eq("publish_type", "public")
+    .maybeSingle();
+  return data !== null;
+}


### PR DESCRIPTION
## Summary
- `isPublicRegulation` ユーティリティを新規作成し、`regulation_items` の `publish_type = 'public'` チェックを一元化
- `getRegulationItems` のクエリに `.eq("publish_type", "public")` を追加（RLS に加えてクライアント側でも明示的にフィルタ）
- `getGodItems` / `getRaceItems` / `getSchoolItems` / `getSupplementItems` の `type: "period"` 取得時に公開状態チェックを追加（非公開レギュレーションの場合は空配列を返す）

## Issue
Close #29

## Test plan
- [ ] 公開状態（publish_type = 'public'）のレギュレーションが一覧・詳細で正常に表示される
- [ ] 非公開（draft）のレギュレーションがクライアント画面に表示されない
- [ ] 非公開レギュレーションの ID を URL に直接入力しても、神格・種族・流派・サプリメントが表示されない
- [ ] 公開レギュレーションに紐づく神格等のデータは従来通り表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)