### PR TITLE
E-31 FormRecord の型定義を RowValue と互換させビルドエラーを解消

### DIFF
--- a/application/frontend/admin/const/type/config/EntityConfigType.ts
+++ b/application/frontend/admin/const/type/config/EntityConfigType.ts
@@ -1,7 +1,7 @@
 import type { TableColumnType, TableRow } from "@/const/type/table/TableColumnType";
 import type { FormItemType } from "@/const/type/form/FormItemType";
 
-export type FormRecord = Record<string, string | number | boolean | string[] | number[] | null>;
+export type FormRecord = Record<string, string | number | boolean | string[] | number[] | (string | number)[] | Record<string, string | number | boolean | null> | null>;
 
 export type EntityConfigType = {
   apiType: string;


### PR DESCRIPTION
## Summary

- `RowValue` が含む `Record<string, string | number | boolean | null>` が `FormRecord` に含まれておらず、`toForm` の戻り値で型エラーが発生していた
- `FormRecord` に `Record<string, string | number | boolean | null>` を追加して解消

## Test plan

- [ ] Vercel ビルドが成功すること
- [ ] `npm run build` がエラーなく完了すること

closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)