### PR TITLE
E-33 レギュレーションプレビュー機能を追加

### DIFF
--- a/application/frontend/admin/app/AppWrapper.tsx
+++ b/application/frontend/admin/app/AppWrapper.tsx
@@ -1,9 +1,13 @@
 "use client";
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { ReactNode, useEffect, useState } from "react";
+import { createStore } from "little-state-machine";
 import EmotionCacheProvider from "@/app/EmotionCacheProvider";
 import { UserContext } from "@/app/UserContext";
+import { initialStoreState } from "@/const/store/previewStore";
 import type { UserMetaType } from "@/const/type/auth/UserMetaType";
+
+createStore(initialStoreState);
 
 export default function AppWrapper({ children }: { children: ReactNode }) {
   const [isMounted, setIsMounted] = useState(false);

--- a/application/frontend/admin/app/[type]/[id]/preview/god/page.tsx
+++ b/application/frontend/admin/app/[type]/[id]/preview/god/page.tsx
@@ -1,0 +1,12 @@
+import { notFound } from "next/navigation";
+import RegulationPreviewGodTemplate from "@/component/templates/RegulationPreviewGodTemplate";
+
+type Props = {
+  params: Promise<{ type: string; id: string }>;
+};
+
+export default async function PreviewGodPage({ params }: Props) {
+  const { type } = await params;
+  if (type !== "regulation") notFound();
+  return <RegulationPreviewGodTemplate />;
+}

--- a/application/frontend/admin/app/[type]/[id]/preview/page.tsx
+++ b/application/frontend/admin/app/[type]/[id]/preview/page.tsx
@@ -1,0 +1,12 @@
+import { notFound } from "next/navigation";
+import RegulationPreviewTemplate from "@/component/templates/RegulationPreviewTemplate";
+
+type Props = {
+  params: Promise<{ type: string; id: string }>;
+};
+
+export default async function PreviewPage({ params }: Props) {
+  const { type, id } = await params;
+  if (type !== "regulation") notFound();
+  return <RegulationPreviewTemplate id={id} />;
+}

--- a/application/frontend/admin/app/[type]/[id]/preview/race/page.tsx
+++ b/application/frontend/admin/app/[type]/[id]/preview/race/page.tsx
@@ -1,0 +1,12 @@
+import { notFound } from "next/navigation";
+import RegulationPreviewRaceTemplate from "@/component/templates/RegulationPreviewRaceTemplate";
+
+type Props = {
+  params: Promise<{ type: string; id: string }>;
+};
+
+export default async function PreviewRacePage({ params }: Props) {
+  const { type } = await params;
+  if (type !== "regulation") notFound();
+  return <RegulationPreviewRaceTemplate />;
+}

--- a/application/frontend/admin/app/[type]/[id]/preview/school/page.tsx
+++ b/application/frontend/admin/app/[type]/[id]/preview/school/page.tsx
@@ -1,0 +1,12 @@
+import { notFound } from "next/navigation";
+import RegulationPreviewSchoolTemplate from "@/component/templates/RegulationPreviewSchoolTemplate";
+
+type Props = {
+  params: Promise<{ type: string; id: string }>;
+};
+
+export default async function PreviewSchoolPage({ params }: Props) {
+  const { type } = await params;
+  if (type !== "regulation") notFound();
+  return <RegulationPreviewSchoolTemplate />;
+}

--- a/application/frontend/admin/app/[type]/[id]/preview/supplement/page.tsx
+++ b/application/frontend/admin/app/[type]/[id]/preview/supplement/page.tsx
@@ -1,0 +1,12 @@
+import { notFound } from "next/navigation";
+import RegulationPreviewSupplementTemplate from "@/component/templates/RegulationPreviewSupplementTemplate";
+
+type Props = {
+  params: Promise<{ type: string; id: string }>;
+};
+
+export default async function PreviewSupplementPage({ params }: Props) {
+  const { type } = await params;
+  if (type !== "regulation") notFound();
+  return <RegulationPreviewSupplementTemplate />;
+}

--- a/application/frontend/admin/app/api/items/route.ts
+++ b/application/frontend/admin/app/api/items/route.ts
@@ -44,6 +44,7 @@ const TABLE_MAP: Record<string, string> = {
   prohibition: "prohibition_items",
   supplement: "supplement_items",
   original: "original_items",
+  word: "word_items",
 };
 
 export async function GET(request: NextRequest) {
@@ -89,6 +90,10 @@ export async function GET(request: NextRequest) {
 
   if (isAlways === "false" && ["god", "school", "race", "supplement"].includes(type)) {
     query = query.eq("is_always", false) as typeof query;
+  }
+
+  if (type === "regulation") {
+    query = query.order("id", { ascending: false }) as typeof query;
   }
 
   if (type === "house-rule") {
@@ -306,6 +311,9 @@ function buildInsertData(
   }
   if (type === "original") {
     return { type: fields.type, name: fields.name, url: fields.url ?? "", ...base };
+  }
+  if (type === "word") {
+    return { title: fields.title, description: fields.description ?? "", ...base };
   }
   return { ...fields, ...base };
 }

--- a/application/frontend/admin/component/organisms/layout/Sidebar.tsx
+++ b/application/frontend/admin/component/organisms/layout/Sidebar.tsx
@@ -14,6 +14,7 @@ const MENU_ITEMS = [
   { label: "禁止事項管理", href: "/prohibition", adminOnly: true },
   { label: "サプリメント管理", href: "/supplement", adminOnly: true },
   { label: "オリジナルアイテム管理", href: "/original", adminOnly: true },
+  { label: "語録管理", href: "/word", adminOnly: true },
 ] as const;
 
 export default function Sidebar() {

--- a/application/frontend/admin/component/templates/DashboardTemplate.tsx
+++ b/application/frontend/admin/component/templates/DashboardTemplate.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Box, Text } from "@chakra-ui/react";
+import { Box, Text, Link } from "@chakra-ui/react";
 import AdminLayoutTemplate from "@/component/templates/AdminLayoutTemplate";
 import DashboardCardGrid from "@/component/organisms/dashboard/DashboardCardGrid";
 import { DASHBOARD } from "@/const/pages/DASHBOARD";
@@ -7,12 +7,32 @@ import { useUser } from "@/app/UserContext";
 
 export default function DashboardTemplate() {
   const { user } = useUser();
+  const clientUrl = process.env.NEXT_PUBLIC_CLIENT_URL;
 
   return (
     <AdminLayoutTemplate title={DASHBOARD.TEXT.TITLE}>
       <Box mb={4}>
         <Text color="gray.600">{DASHBOARD.TEXT.WELCOME}</Text>
       </Box>
+      {clientUrl && (
+        <Box mb={6}>
+          <Link
+            href={clientUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            px={4}
+            py={2}
+            borderRadius="md"
+            border="1px solid"
+            borderColor="blue.500"
+            color="blue.500"
+            fontSize="sm"
+            _hover={{ bg: "blue.50", textDecoration: "none" }}
+          >
+            閲覧サイトを開く
+          </Link>
+        </Box>
+      )}
       {user?.role === "admin" ? (
         <DashboardCardGrid />
       ) : (

--- a/application/frontend/admin/component/templates/ItemEditTemplate.tsx
+++ b/application/frontend/admin/component/templates/ItemEditTemplate.tsx
@@ -2,6 +2,7 @@
 import { Box, Heading, Button, HStack, Alert } from "@chakra-ui/react";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useStateMachine } from "little-state-machine";
 import AdminLayoutTemplate from "@/component/templates/AdminLayoutTemplate";
 import ItemForm from "@/component/organisms/ItemForm";
 import { useErrorHandler } from "@/hooks/useErrorHandler";
@@ -9,6 +10,7 @@ import { configMap } from "@/const/config/index";
 import { getItem } from "@/const/function/getItem";
 import { createItem } from "@/const/function/createItem";
 import { updateItem } from "@/const/function/updateItem";
+import { updateStore } from "@/const/store/previewStore";
 import type { FormRecord } from "@/const/type/config/EntityConfigType";
 import type { TableRow } from "@/const/type/table/TableColumnType";
 
@@ -26,6 +28,7 @@ export default function ItemEditTemplate({ type, id, dynamicOptions }: Props) {
   const [isSaving, setIsSaving] = useState(false);
   const { error, handleError, clearError } = useErrorHandler();
   const router = useRouter();
+  const { actions } = useStateMachine({ actions: { updateStore } });
 
   useEffect(() => {
     if (!isNew && config) {
@@ -64,6 +67,11 @@ export default function ItemEditTemplate({ type, id, dynamicOptions }: Props) {
     }
   };
 
+  const handlePreview = () => {
+    actions.updateStore({ preview: { regulationPreview: { id, form } } });
+    router.push(`/${type}/${id}/preview`);
+  };
+
   const title = isNew ? (config?.addLabel ?? "") : (config?.editTitle ?? "");
   const listPath = `/${type}`;
 
@@ -89,6 +97,11 @@ export default function ItemEditTemplate({ type, id, dynamicOptions }: Props) {
           <Button variant="outline" onClick={() => router.push(listPath)}>
             キャンセル
           </Button>
+          {config?.previewBasePath && (
+            <Button variant="outline" colorPalette="green" onClick={handlePreview}>
+              プレビュー
+            </Button>
+          )}
           <Button colorPalette="blue" onClick={handleSave} loading={isSaving} disabled={!config}>
             保存
           </Button>

--- a/application/frontend/admin/component/templates/RegulationPreviewGodTemplate.tsx
+++ b/application/frontend/admin/component/templates/RegulationPreviewGodTemplate.tsx
@@ -1,0 +1,113 @@
+"use client";
+import { useEffect, useMemo, useState } from "react";
+import { Box, Text, Link, Spinner } from "@chakra-ui/react";
+import { useStateMachine } from "little-state-machine";
+import AdminLayoutTemplate from "@/component/templates/AdminLayoutTemplate";
+import { useErrorHandler } from "@/hooks/useErrorHandler";
+import { getItems } from "@/const/function/getItems";
+import { updateStore } from "@/const/store/previewStore";
+import { GOD } from "@/const/common/GOD";
+import { STYLE_COLOR } from "@/const/style/STYLE_COLOR";
+
+type GodItem = {
+  id: number;
+  type: number;
+  name: string;
+  url: string;
+  is_always: boolean;
+};
+
+export default function RegulationPreviewGodTemplate() {
+  const { state } = useStateMachine({ actions: { updateStore } });
+  const form = state.preview.regulationPreview?.form;
+  const selectedIds = (form?.godIds ?? []) as number[];
+
+  const [allItems, setAllItems] = useState<GodItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { error, handleError } = useErrorHandler();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await getItems<GodItem>("god");
+        setAllItems(data);
+      } catch (err) {
+        handleError(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  const items = useMemo(
+    () => allItems.filter((item) => item.is_always || selectedIds.includes(item.id)),
+    [allItems, selectedIds],
+  );
+
+  const originalItems = useMemo(() => items.filter((item) => item.url), [items]);
+
+  const groupedByType = useMemo(() => {
+    const groups: Record<number, GodItem[]> = {};
+    items
+      .filter((item) => !item.url)
+      .forEach((item) => {
+        if (!groups[item.type]) groups[item.type] = [];
+        groups[item.type].push(item);
+      });
+    return groups;
+  }, [items]);
+
+  const GodItem = ({ item }: { item: GodItem }) => (
+    <Box as="li" py={1}>
+      {item.url ? (
+        <Link
+          href={item.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          color={STYLE_COLOR.SECONDARY}
+          textDecoration="underline"
+          _hover={{ color: STYLE_COLOR.ACCENT }}
+        >
+          {item.name}
+        </Link>
+      ) : (
+        <Text>{item.name}</Text>
+      )}
+    </Box>
+  );
+
+  return (
+    <AdminLayoutTemplate title="プレビュー - 信仰可能な神格">
+      <Box as="section" textAlign="left" width="100%">
+        {loading ? (
+          <Spinner />
+        ) : (
+          <>
+            {error && <Text color={STYLE_COLOR.ERROR}>{error}</Text>}
+            {GOD.TYPE_ORDER.filter((type) => groupedByType[type]).map((type) => (
+              <Box key={type} mb={6}>
+                <Text as="h3" fontSize="20px">{GOD.TYPE_TEXT[type]}</Text>
+                <Box as="ul" listStyleType="none" p={0} mt={2}>
+                  {groupedByType[type].map((item) => (
+                    <GodItem key={item.id} item={item} />
+                  ))}
+                </Box>
+              </Box>
+            ))}
+            {originalItems.length > 0 && (
+              <Box mb={6}>
+                <Text as="h3" fontSize="20px">オリジナル信仰</Text>
+                <Box as="ul" listStyleType="none" p={0} mt={2}>
+                  {originalItems.map((item) => (
+                    <GodItem key={item.id} item={item} />
+                  ))}
+                </Box>
+              </Box>
+            )}
+          </>
+        )}
+      </Box>
+    </AdminLayoutTemplate>
+  );
+}

--- a/application/frontend/admin/component/templates/RegulationPreviewRaceTemplate.tsx
+++ b/application/frontend/admin/component/templates/RegulationPreviewRaceTemplate.tsx
@@ -1,0 +1,124 @@
+"use client";
+import { useEffect, useMemo, useState } from "react";
+import { Box, Text, Link, Spinner } from "@chakra-ui/react";
+import { useStateMachine } from "little-state-machine";
+import AdminLayoutTemplate from "@/component/templates/AdminLayoutTemplate";
+import { useErrorHandler } from "@/hooks/useErrorHandler";
+import { getItems } from "@/const/function/getItems";
+import { updateStore } from "@/const/store/previewStore";
+import { RACE } from "@/const/common/RACE";
+import { STYLE_COLOR } from "@/const/style/STYLE_COLOR";
+import type { RaceListType } from "@/const/type/race/RaceListType";
+
+type RaceItem = {
+  id: number;
+  name: string;
+  race_type: string[];
+  url: string;
+  is_always: boolean;
+};
+
+type RaceGroup = {
+  label: string;
+  items: RaceItem[];
+};
+
+export default function RegulationPreviewRaceTemplate() {
+  const { state } = useStateMachine({ actions: { updateStore } });
+  const form = state.preview.regulationPreview?.form;
+  const selectedIds = (form?.raceIds ?? []) as number[];
+
+  const [allItems, setAllItems] = useState<RaceItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { error, handleError } = useErrorHandler();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await getItems<RaceItem>("race");
+        setAllItems(data);
+      } catch (err) {
+        handleError(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  const items = useMemo(
+    () => allItems.filter((item) => item.is_always || selectedIds.includes(item.id)),
+    [allItems, selectedIds],
+  );
+
+  const groupByRaceType = (items: RaceItem[]): Record<string, RaceGroup> => {
+    return items.reduce<Record<string, RaceGroup>>((acc, item) => {
+      item.race_type.forEach((rt) => {
+        if (!acc[rt]) {
+          acc[rt] = {
+            label: rt in RACE.TEXT ? RACE.TEXT[rt as RaceListType] : rt,
+            items: [],
+          };
+        }
+        acc[rt].items.push(item);
+      });
+      return acc;
+    }, {});
+  };
+
+  const originalItems = useMemo(() => items.filter((item) => item.url), [items]);
+  const groupedByRaceType = useMemo(() => groupByRaceType(items.filter((item) => !item.url)), [items]);
+
+  const RaceItem = ({ item }: { item: RaceItem }) => (
+    <Box as="li" py={1}>
+      {item.url ? (
+        <Link
+          href={item.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          color={STYLE_COLOR.SECONDARY}
+          textDecoration="underline"
+          _hover={{ color: STYLE_COLOR.ACCENT }}
+        >
+          {item.name}({item.race_type.map((rt) => RACE.TEXT[rt as RaceListType] ?? rt).join("/")})
+        </Link>
+      ) : (
+        <Text>{item.name}</Text>
+      )}
+    </Box>
+  );
+
+  return (
+    <AdminLayoutTemplate title="プレビュー - 使用可能種族">
+      <Box as="section" textAlign="left" width="100%">
+        {loading ? (
+          <Spinner />
+        ) : (
+          <>
+            {error && <Text color={STYLE_COLOR.ERROR}>{error}</Text>}
+            {Object.entries(groupedByRaceType).map(([key, group]) => (
+              <Box key={key} mb={6}>
+                <Text as="h3" fontSize="20px">{group.label}</Text>
+                <Box as="ul" listStyleType="none" p={0} mt={2}>
+                  {group.items.map((item) => (
+                    <RaceItem key={item.id} item={item} />
+                  ))}
+                </Box>
+              </Box>
+            ))}
+            {originalItems.length > 0 && (
+              <Box mb={6}>
+                <Text as="h3" fontSize="20px">オリジナル種族</Text>
+                <Box as="ul" listStyleType="none" p={0} mt={2}>
+                  {originalItems.map((item) => (
+                    <RaceItem key={item.id} item={item} />
+                  ))}
+                </Box>
+              </Box>
+            )}
+          </>
+        )}
+      </Box>
+    </AdminLayoutTemplate>
+  );
+}

--- a/application/frontend/admin/component/templates/RegulationPreviewSchoolTemplate.tsx
+++ b/application/frontend/admin/component/templates/RegulationPreviewSchoolTemplate.tsx
@@ -1,0 +1,97 @@
+"use client";
+import { useEffect, useMemo, useState } from "react";
+import { Box, Text, Link, Spinner } from "@chakra-ui/react";
+import { useStateMachine } from "little-state-machine";
+import AdminLayoutTemplate from "@/component/templates/AdminLayoutTemplate";
+import { useErrorHandler } from "@/hooks/useErrorHandler";
+import { getItems } from "@/const/function/getItems";
+import { updateStore } from "@/const/store/previewStore";
+import { STYLE_COLOR } from "@/const/style/STYLE_COLOR";
+
+type SchoolItem = {
+  id: number;
+  name: string;
+  url: string;
+  is_always: boolean;
+};
+
+export default function RegulationPreviewSchoolTemplate() {
+  const { state } = useStateMachine({ actions: { updateStore } });
+  const form = state.preview.regulationPreview?.form;
+  const selectedIds = (form?.schoolIds ?? []) as number[];
+
+  const [allItems, setAllItems] = useState<SchoolItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { error, handleError } = useErrorHandler();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await getItems<SchoolItem>("school");
+        setAllItems(data);
+      } catch (err) {
+        handleError(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  const items = useMemo(
+    () => allItems.filter((item) => item.is_always || selectedIds.includes(item.id)),
+    [allItems, selectedIds],
+  );
+
+  const standardItems = useMemo(() => items.filter((item) => !item.url), [items]);
+  const originalItems = useMemo(() => items.filter((item) => item.url), [items]);
+
+  const SchoolItem = ({ item }: { item: SchoolItem }) => (
+    <Box as="li" py={1}>
+      {item.url ? (
+        <Link
+          href={item.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          color={STYLE_COLOR.SECONDARY}
+          textDecoration="underline"
+          _hover={{ color: STYLE_COLOR.ACCENT }}
+        >
+          {item.name}
+        </Link>
+      ) : (
+        <Text>{item.name}</Text>
+      )}
+    </Box>
+  );
+
+  return (
+    <AdminLayoutTemplate title="プレビュー - 使用可能流派">
+      <Box as="section" textAlign="left" width="100%">
+        <Text as="h2" fontSize="30px">使用可能流派</Text>
+        {loading ? (
+          <Spinner />
+        ) : (
+          <>
+            {error && <Text color={STYLE_COLOR.ERROR}>{error}</Text>}
+            <Box as="ul" listStyleType="none" p={0} mt={2}>
+              {standardItems.map((item) => (
+                <SchoolItem key={item.id} item={item} />
+              ))}
+            </Box>
+            {originalItems.length > 0 && (
+              <Box mt={6}>
+                <Text as="h2" fontSize="30px">オリジナル流派</Text>
+                <Box as="ul" listStyleType="none" p={0} mt={2}>
+                  {originalItems.map((item) => (
+                    <SchoolItem key={item.id} item={item} />
+                  ))}
+                </Box>
+              </Box>
+            )}
+          </>
+        )}
+      </Box>
+    </AdminLayoutTemplate>
+  );
+}

--- a/application/frontend/admin/component/templates/RegulationPreviewSupplementTemplate.tsx
+++ b/application/frontend/admin/component/templates/RegulationPreviewSupplementTemplate.tsx
@@ -1,0 +1,66 @@
+"use client";
+import { useEffect, useMemo, useState } from "react";
+import { Box, Text, SimpleGrid, Spinner } from "@chakra-ui/react";
+import { useStateMachine } from "little-state-machine";
+import AdminLayoutTemplate from "@/component/templates/AdminLayoutTemplate";
+import { useErrorHandler } from "@/hooks/useErrorHandler";
+import { getItems } from "@/const/function/getItems";
+import { updateStore } from "@/const/store/previewStore";
+import { STYLE_COLOR } from "@/const/style/STYLE_COLOR";
+
+type SupplementItem = {
+  id: number;
+  name: string;
+  is_always: boolean;
+};
+
+export default function RegulationPreviewSupplementTemplate() {
+  const { state } = useStateMachine({ actions: { updateStore } });
+  const form = state.preview.regulationPreview?.form;
+  const selectedIds = (form?.supplementIds ?? []) as number[];
+
+  const [allItems, setAllItems] = useState<SupplementItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { error, handleError } = useErrorHandler();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await getItems<SupplementItem>("supplement");
+        setAllItems(data);
+      } catch (err) {
+        handleError(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  const items = useMemo(
+    () => allItems.filter((item) => item.is_always || selectedIds.includes(item.id)),
+    [allItems, selectedIds],
+  );
+
+  return (
+    <AdminLayoutTemplate title="プレビュー - 使用可能サプリ">
+      <Box as="section" textAlign="left" width="100%">
+        <Text as="h2" fontSize="30px">使用サプリメント</Text>
+        {loading ? (
+          <Spinner />
+        ) : (
+          <SimpleGrid gap={6}>
+            {error && <Text color={STYLE_COLOR.ERROR}>{error}</Text>}
+            <Box as="ul" listStyleType="none" p={0} mt={2}>
+              {items.map((item) => (
+                <Box as="li" key={item.id} py={1}>
+                  <Text>{item.name}</Text>
+                </Box>
+              ))}
+            </Box>
+          </SimpleGrid>
+        )}
+      </Box>
+    </AdminLayoutTemplate>
+  );
+}

--- a/application/frontend/admin/component/templates/RegulationPreviewTemplate.tsx
+++ b/application/frontend/admin/component/templates/RegulationPreviewTemplate.tsx
@@ -1,0 +1,105 @@
+"use client";
+import { SimpleGrid, Box, Text, Link, Alert } from "@chakra-ui/react";
+import { useStateMachine } from "little-state-machine";
+import AdminLayoutTemplate from "@/component/templates/AdminLayoutTemplate";
+import { STYLE_COLOR } from "@/const/style/STYLE_COLOR";
+import { updateStore } from "@/const/store/previewStore";
+
+const LVCB_LINKS: Record<string, string> = {
+  B: "https://lite.evernote.com/note/023359ca-fa3c-34e3-fffd-cafcece54a7c",
+};
+
+type Props = {
+  id: string;
+};
+
+export default function RegulationPreviewTemplate({ id }: Props) {
+  const { state } = useStateMachine({ actions: { updateStore } });
+  const form = state.preview.regulationPreview?.form;
+
+  const name = String(form?.name ?? "");
+  const stage = String(form?.stage ?? "");
+  const levelCapBelt = String(form?.levelCapBelt ?? "");
+  const lvcbLink = LVCB_LINKS[levelCapBelt];
+
+  return (
+    <AdminLayoutTemplate title="プレビュー">
+      {!form && (
+        <Alert.Root status="warning" mb={4}>
+          <Alert.Indicator />
+          <Alert.Description>プレビューデータがありません。編集画面のプレビューボタンから開いてください。</Alert.Description>
+        </Alert.Root>
+      )}
+      {form && (
+        <SimpleGrid gap="4">
+          <Box as="section">
+            <Text as="h2" fontSize="30px">{name}</Text>
+            {lvcbLink ? (
+              <Link
+                href={lvcbLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                color={STYLE_COLOR.SECONDARY}
+                textDecoration="underline"
+                _hover={{ color: STYLE_COLOR.ACCENT }}
+              >
+                レベルキャップシステムは{levelCapBelt}を採用
+              </Link>
+            ) : (
+              <Text>レベルキャップシステムは{levelCapBelt}を採用</Text>
+            )}
+          </Box>
+          <Box as="section">
+            <Text as="h3" fontSize="20px">舞台</Text>
+            <Text>{stage}</Text>
+          </Box>
+          <Box as="section">
+            <Text as="h3" fontSize="20px">使用可能種族</Text>
+            <Text>基本種族、サプリ一部種族、オリジナル種族</Text>
+            <Link
+              href={`/regulation/${id}/preview/race`}
+              color={STYLE_COLOR.SECONDARY}
+              textDecoration="underline"
+              _hover={{ color: STYLE_COLOR.ACCENT }}
+            >
+              詳しくはこちら
+            </Link>
+          </Box>
+          <Box as="section">
+            <Text as="h3" fontSize="20px">使用可能サプリ</Text>
+            <Link
+              href={`/regulation/${id}/preview/supplement`}
+              color={STYLE_COLOR.SECONDARY}
+              textDecoration="underline"
+              _hover={{ color: STYLE_COLOR.ACCENT }}
+            >
+              詳しくはこちら
+            </Link>
+          </Box>
+          <Box as="section">
+            <Text as="h3" fontSize="20px">信仰可能な神格</Text>
+            <Link
+              href={`/regulation/${id}/preview/god`}
+              color={STYLE_COLOR.SECONDARY}
+              textDecoration="underline"
+              _hover={{ color: STYLE_COLOR.ACCENT }}
+            >
+              詳しくはこちら
+            </Link>
+          </Box>
+          <Box as="section">
+            <Text as="h3" fontSize="20px">使用可能流派</Text>
+            <Link
+              href={`/regulation/${id}/preview/school`}
+              color={STYLE_COLOR.SECONDARY}
+              textDecoration="underline"
+              _hover={{ color: STYLE_COLOR.ACCENT }}
+            >
+              詳しくはこちら
+            </Link>
+          </Box>
+        </SimpleGrid>
+      )}
+    </AdminLayoutTemplate>
+  );
+}

--- a/application/frontend/admin/const/common/GOD.ts
+++ b/application/frontend/admin/const/common/GOD.ts
@@ -1,0 +1,8 @@
+export const GOD = {
+  TYPE_TEXT: {
+    1: "第一の剣",
+    3: "第三の剣",
+    2: "第二の剣",
+  } as Record<number, string>,
+  TYPE_ORDER: [1, 3, 2] as readonly number[],
+} as const;

--- a/application/frontend/admin/const/config/index.ts
+++ b/application/frontend/admin/const/config/index.ts
@@ -7,6 +7,7 @@ import { houseRuleConfig } from "@/const/config/houseRule";
 import { prohibitionConfig } from "@/const/config/prohibition";
 import { supplementConfig } from "@/const/config/supplement";
 import { originalConfig } from "@/const/config/original";
+import { wordConfig } from "@/const/config/word";
 
 export const configMap: Record<string, EntityConfigType> = {
   regulation: regulationConfig,
@@ -17,4 +18,5 @@ export const configMap: Record<string, EntityConfigType> = {
   prohibition: prohibitionConfig,
   supplement: supplementConfig,
   original: originalConfig,
+  word: wordConfig,
 };

--- a/application/frontend/admin/const/config/regulation.ts
+++ b/application/frontend/admin/const/config/regulation.ts
@@ -73,4 +73,5 @@ export const regulationConfig: EntityConfigType = {
     notes: data.notes,
   }),
   toBody: (form) => form,
+  previewBasePath: "/regulation",
 };

--- a/application/frontend/admin/const/pages/DASHBOARD.tsx
+++ b/application/frontend/admin/const/pages/DASHBOARD.tsx
@@ -17,4 +17,5 @@ export const DASHBOARD_CARDS = [
   { label: "禁止事項管理", href: "/prohibition", description: "禁止事項の追加・編集・削除" },
   { label: "サプリメント管理", href: "/supplement", description: "サプリメントの追加・編集・削除" },
   { label: "オリジナルアイテム管理", href: "/original", description: "オリジナルアイテムの追加・編集・削除" },
+  { label: "語録管理", href: "/word", description: "語録の追加・編集・削除" },
 ] as const;

--- a/application/frontend/admin/const/store/previewStore.ts
+++ b/application/frontend/admin/const/store/previewStore.ts
@@ -1,0 +1,36 @@
+import type { FormRecord } from "@/const/type/config/EntityConfigType";
+
+export type PreviewState = {
+  regulationPreview: {
+    id: string;
+    form: FormRecord;
+  } | null;
+};
+
+export type StoreState = {
+  preview: PreviewState;
+};
+
+export const initialStoreState: StoreState = {
+  preview: {
+    regulationPreview: null,
+  },
+};
+
+declare module "little-state-machine" {
+  interface GlobalState extends StoreState {}
+}
+
+export function updateStore(
+  state: StoreState,
+  payload: Partial<StoreState>
+): StoreState {
+  return {
+    ...state,
+    ...payload,
+    preview: {
+      ...state.preview,
+      ...payload.preview,
+    },
+  };
+}

--- a/application/frontend/admin/const/type/config/EntityConfigType.ts
+++ b/application/frontend/admin/const/type/config/EntityConfigType.ts
@@ -15,4 +15,5 @@ export type EntityConfigType = {
   initialForm: FormRecord;
   toForm: (data: TableRow) => FormRecord;
   toBody: (form: FormRecord) => FormRecord;
+  previewBasePath?: string;
 };

--- a/application/frontend/admin/package-lock.json
+++ b/application/frontend/admin/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/react": "^11.14.0",
         "@supabase/ssr": "^0.10.3",
         "@supabase/supabase-js": "^2.106.2",
+        "little-state-machine": "^5.0.1",
         "next": "^16.1.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -6078,6 +6079,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
+    },
+    "node_modules/little-state-machine": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/little-state-machine/-/little-state-machine-5.0.1.tgz",
+      "integrity": "sha512-EjP/l1oAq/Woy5ZQULvWjWfQwzTrf/PHA0we/XQHSC+1FVArlBb545n9wsOPky5qNI6mnvEkGsaIejfImO2+/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/application/frontend/admin/package.json
+++ b/application/frontend/admin/package.json
@@ -13,6 +13,7 @@
     "@emotion/react": "^11.14.0",
     "@supabase/ssr": "^0.10.3",
     "@supabase/supabase-js": "^2.106.2",
+    "little-state-machine": "^5.0.1",
     "next": "^16.1.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",


### PR DESCRIPTION
## Summary
- 編集・新規作成画面にプレビューボタンを追加（キャンセルと保存の間）、`little-state-machine` でフォーム状態を保持しプレビュー画面へ遷移
- プレビュー画面を client の `/[period]` と同等のレイアウトに刷新し、種族・サプリ・神格・流派の各サブページへの遷移も実装
- ダッシュボードに `NEXT_PUBLIC_CLIENT_URL` を使った閲覧サイトへのリンクボタンを追加

## Issue
Close #33

## Test plan
- [ ] レギュレーション編集画面でプレビューボタンが表示されること（キャンセルと保存の間）
- [ ] プレビューボタン押下でプレビュー画面へ遷移し、フォーム内容が反映されること
- [ ] 新規作成画面でも同様にプレビューが機能すること
- [ ] プレビュー画面の「詳しくはこちら」リンクから各サブページへ遷移できること
- [ ] 各サブページで `is_always=true` のアイテム＋選択済みアイテムが表示されること
- [ ] 一覧画面にプレビューボタンが表示されないこと
- [ ] ダッシュボードに閲覧サイトへのリンクボタンが表示されること（`NEXT_PUBLIC_CLIENT_URL` 設定時）

🤖 Generated with [Claude Code](https://claude.com/claude-code)