### PR TITLE
E-36 wordConfig の未コミットファイルを追加

### DIFF
--- a/application/frontend/admin/const/config/word.ts
+++ b/application/frontend/admin/const/config/word.ts
@@ -1,0 +1,26 @@
+import type { EntityConfigType } from "@/const/type/config/EntityConfigType";
+
+export const wordConfig: EntityConfigType = {
+  apiType: "word",
+  listTitle: "語録管理",
+  addLabel: "語録を追加",
+  editTitle: "語録を編集",
+  deleteConfirm: "この語録を削除しますか？",
+  initialForm: {
+    title: "",
+    description: "",
+  },
+  columns: [
+    { key: "id", label: "ID" },
+    { key: "title", label: "タイトル" },
+  ],
+  formItems: [
+    { column: "title", label: "タイトル", type: "text", rule: { required: true } },
+    { column: "description", label: "内容", type: "textarea" },
+  ],
+  toForm: (data) => ({
+    title: data.title,
+    description: data.description ?? "",
+  }),
+  toBody: (form) => form,
+};


### PR DESCRIPTION
## Summary
- `const/config/word.ts` が未コミットのままデプロイされ、ビルドエラーになっていたため追加

## Issue
Close #36

## Test plan
- [ ] デプロイが成功すること
- [ ] 語録管理ページが正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)