### PR TITLE
E-34 語録一覧・サプリnotes表示・ハンバーガーメニュー改修

### DIFF
--- a/application/frontend/client/app/globals.scss
+++ b/application/frontend/client/app/globals.scss
@@ -1,7 +1,7 @@
 html,
 body,
 * {
-  font-family: var(--font-edu-nsw-act-cursive), var(--font-zen-maru-gothic) !important;
+  font-family: var(--font-zen-maru-gothic);
 }
 
 body,

--- a/application/frontend/client/app/word/page.tsx
+++ b/application/frontend/client/app/word/page.tsx
@@ -1,0 +1,13 @@
+import WordTemplate from "@/component/templates/WordTemplate";
+import { COMMON } from "@/const/common/COMMON";
+import { METADATA } from "@/const/common/METADATA";
+
+export const dynamic = "force-static";
+export const metadata = {
+  title: COMMON.SITE_NAME + "|" + METADATA.TITLE.WORD,
+  description: METADATA.DESCRIPTION.WORD,
+};
+
+export default function Word() {
+  return <WordTemplate />;
+}

--- a/application/frontend/client/component/atoms/HeadingSecond.tsx
+++ b/application/frontend/client/component/atoms/HeadingSecond.tsx
@@ -2,13 +2,13 @@
 import { PATH } from "@/const/common/PATH";
 import { Image, Text } from "@chakra-ui/react";
 
-interface Props {
+type Props = {
   title: string;
-}
+};
 
 export default function HeadingSecond({ title }: Props) {
   return (
-    <Text as="h2" display="flex" alignItems="center" fontSize="30px">
+    <Text as="h2" display="flex" alignItems="center" fontSize="30px" fontFamily="var(--font-edu-nsw-act-cursive), var(--font-zen-maru-gothic)">
       <Image src={PATH.IMG.COMMON.LOGO} alt="logo" width={"50px"} />
       {title}
     </Text>

--- a/application/frontend/client/component/atoms/HeadingThird.tsx
+++ b/application/frontend/client/component/atoms/HeadingThird.tsx
@@ -1,13 +1,13 @@
 "use client";
 import { Text } from "@chakra-ui/react";
 
-interface Props {
+type Props = {
   title: string;
-}
+};
 
 export default function HeadingThird({ title }: Props) {
   return (
-    <Text as="h3" fontSize="20px">
+    <Text as="h3" fontSize="20px" fontFamily="var(--font-edu-nsw-act-cursive), var(--font-zen-maru-gothic)">
       {title}
     </Text>
   );

--- a/application/frontend/client/component/molecules/Header.tsx
+++ b/application/frontend/client/component/molecules/Header.tsx
@@ -28,45 +28,17 @@ export default function Header() {
   const Backdrop = () => (
     <Box
       position={"fixed"}
-      top={"60px"}
+      top={0}
       left={0}
       width={"100%"}
       height={"100%"}
       bg={"rgba(0,0,0,0.4)"}
-      zIndex={3}
+      zIndex={6}
+      opacity={isOpen ? 1 : 0}
+      pointerEvents={isOpen ? "auto" : "none"}
+      transition={"opacity 0.3s ease"}
       onClick={() => setIsOpen(false)}
     />
-  );
-
-  const MenuPanel = () => (
-    <Box
-      position={"fixed"}
-      top={"60px"}
-      left={0}
-      width={"100%"}
-      bg={STYLE_COLOR.COMMON}
-      zIndex={4}
-      boxShadow={"0 4px 12px rgba(0,0,0,0.1)"}
-      py={4}
-      px={6}
-    >
-      <Box as="nav">
-        {navItems.map((item, index) => (
-          <Box
-            key={item.href}
-            py={3}
-            fontSize={"15px"}
-            color={STYLE_COLOR.BLACK}
-            borderBottom={index < navItems.length - 1 ? `1px solid ${STYLE_COLOR.LIGHT}` : undefined}
-            _hover={{ color: STYLE_COLOR.PRIMARY }}
-          >
-            <Link href={item.href} onClick={() => setIsOpen(false)}>
-              {item.label}
-            </Link>
-          </Box>
-        ))}
-      </Box>
-    </Box>
   );
 
   return (
@@ -105,12 +77,51 @@ export default function Header() {
           </Box>
         </Box>
       </Box>
-      {isOpen && (
-        <>
-          <Backdrop />
-          <MenuPanel />
-        </>
-      )}
+      <Backdrop />
+      <Box
+        position={"fixed"}
+        top={0}
+        right={0}
+        width={"280px"}
+        height={"100%"}
+        bg={STYLE_COLOR.COMMON}
+        zIndex={7}
+        boxShadow={"-4px 0 12px rgba(0,0,0,0.15)"}
+        transform={isOpen ? "translateX(0)" : "translateX(100%)"}
+        transition={"transform 0.3s ease"}
+      >
+        <Box display={"flex"} justifyContent={"flex-end"} px={4} pt={4}>
+          <Box
+            as="button"
+            onClick={() => setIsOpen(false)}
+            cursor={"pointer"}
+            color={STYLE_COLOR.PRIMARY}
+            aria-label="メニューを閉じる"
+          >
+            <RxCross1 size={24} />
+          </Box>
+        </Box>
+        <Box as="nav" py={4} px={6}>
+          {navItems.map((item, index) => (
+            <Link
+              key={item.label}
+              href={item.href}
+              onClick={() => setIsOpen(false)}
+              style={{ display: "block" }}
+            >
+              <Box
+                py={3}
+                fontSize={"15px"}
+                color={STYLE_COLOR.BLACK}
+                borderBottom={index < navItems.length - 1 ? `1px solid ${STYLE_COLOR.LIGHT}` : undefined}
+                _hover={{ color: STYLE_COLOR.PRIMARY }}
+              >
+                {item.label}
+              </Box>
+            </Link>
+          ))}
+        </Box>
+      </Box>
     </>
   );
 }

--- a/application/frontend/client/component/organisms/supplement/SupplementList.tsx
+++ b/application/frontend/client/component/organisms/supplement/SupplementList.tsx
@@ -46,6 +46,9 @@ export default function SupplementList({ period }: Props) {
           {items.map((item) => (
             <Box as="li" key={item.id} py={1}>
               <Text>{item.name}</Text>
+              {item.notes && (
+                <Text fontSize="sm" color="gray.500" mt={0.5} pl={4} wordBreak="break-all">{item.notes}</Text>
+              )}
             </Box>
           ))}
         </Box>

--- a/application/frontend/client/component/organisms/top/MainVisual.tsx
+++ b/application/frontend/client/component/organisms/top/MainVisual.tsx
@@ -41,6 +41,7 @@ export default function MainVisual() {
         left={"0"}
         textAlign={"center"}
         zIndex={2}
+        fontFamily={"var(--font-edu-nsw-act-cursive), var(--font-zen-maru-gothic)"}
       >
         Per aspera ad astra
       </Text>

--- a/application/frontend/client/component/organisms/word/WordList.tsx
+++ b/application/frontend/client/component/organisms/word/WordList.tsx
@@ -1,0 +1,52 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Box, Text, Spinner, SimpleGrid } from "@chakra-ui/react";
+import { useErrorHandler } from "@/hooks/useErrorHandler";
+import { getWordItems } from "@/const/function/getWordItems";
+import { WORD_PAGE } from "@/const/pages/WORD_PAGE";
+import { STYLE_COLOR } from "@/const/style/STYLE_COLOR";
+import type { WordItemType } from "@/const/type/word/WordItemType";
+import type { ErrorType } from "@/const/type/error/ErrorType";
+import HeadingSecond from "@/component/atoms/HeadingSecond";
+
+export default function WordList() {
+  const [items, setItems] = useState<WordItemType[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { handleError, resetError } = useErrorHandler();
+
+  useEffect(() => {
+    setLoading(true);
+    resetError();
+    const fetchData = async () => {
+      try {
+        const data = await getWordItems();
+        setItems(data);
+        setLoading(false);
+      } catch (error) {
+        handleError(error as ErrorType);
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  return (
+    <Box as="section" textAlign="left" width="100%">
+      <HeadingSecond title={WORD_PAGE.TEXT.heading} />
+      {loading ? (
+        <Spinner />
+      ) : (
+        <SimpleGrid gap={4} mt={4}>
+          {items.map((item) => (
+            <Box key={item.id} borderBottom={`1px solid ${STYLE_COLOR.LIGHT}`} pb={4}>
+              <Text fontWeight="bold">{item.title}</Text>
+              {item.description && (
+                <Text mt={1} color={STYLE_COLOR.BLACK}>{item.description}</Text>
+              )}
+            </Box>
+          ))}
+        </SimpleGrid>
+      )}
+    </Box>
+  );
+}

--- a/application/frontend/client/component/templates/WordTemplate.tsx
+++ b/application/frontend/client/component/templates/WordTemplate.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { Box } from "@chakra-ui/react";
+import MainVisual from "@/component/organisms/top/MainVisual";
+import WordList from "@/component/organisms/word/WordList";
+import { STYLE } from "@/const/common/STYLE";
+
+export default function WordTemplate() {
+  return (
+    <>
+      <MainVisual />
+      <Box maxW={STYLE.WIDTH.SECTION} mx="auto" px={6} py={10}>
+        <WordList />
+      </Box>
+    </>
+  );
+}

--- a/application/frontend/client/const/common/METADATA.tsx
+++ b/application/frontend/client/const/common/METADATA.tsx
@@ -10,6 +10,7 @@ export const METADATA = {
     PROHIBITION: "使用禁止アイテム",
     ORIGINAL: "オリジナルデータ",
     PERIOD_LIST: "レギュレーション一覧",
+    WORD: "語録",
   },
   DESCRIPTION: {
     HOME: "片翼の大鷲亭 - TRPGコミュニティポータル",
@@ -22,5 +23,6 @@ export const METADATA = {
     PROHIBITION: "片翼の大鷲亭 - 使用禁止アイテム",
     ORIGINAL: "片翼の大鷲亭 - オリジナルデータ",
     PERIOD_LIST: "片翼の大鷲亭 - レギュレーション一覧",
+    WORD: "片翼の大鷲亭 - 語録",
   },
 };

--- a/application/frontend/client/const/common/NAV_ITEMS.tsx
+++ b/application/frontend/client/const/common/NAV_ITEMS.tsx
@@ -7,5 +7,6 @@ export const NAV_ITEMS = (period: string) =>
     { label: "現在のレギュレーション", href: `/${period}` },
     { label: "ハウスルール", href: PATH.URL.HOUSE_RULE.ROOT },
     { label: "禁止事項", href: PATH.URL.HOUSE_RULE.PROHIBITION },
-    { label: "オリジナルデータ", href: "/original" },
+    { label: "オリジナルデータ", href: PATH.URL.ORIGINAL.ROOT },
+    { label: "語録", href: PATH.URL.WORD },
   ] as const;

--- a/application/frontend/client/const/common/PATH.tsx
+++ b/application/frontend/client/const/common/PATH.tsx
@@ -24,6 +24,7 @@ export const PATH = {
       ROOT: "/house-rule",
       PROHIBITION: "/house-rule/prohibition",
     },
+    WORD: "/word",
   },
   LINK: {
     TWITTER: "https://x.com/sekiyoku_sw25",

--- a/application/frontend/client/const/function/getWordItems.ts
+++ b/application/frontend/client/const/function/getWordItems.ts
@@ -1,0 +1,16 @@
+import { supabase } from "@/lib/supabase";
+import type { WordItemType } from "@/const/type/word/WordItemType";
+
+export async function getWordItems(): Promise<WordItemType[]> {
+  const { data, error } = await supabase
+    .from("word_items")
+    .select("id, title, description")
+    .order("id", { ascending: true });
+  if (error) throw error;
+
+  return data.map((row) => ({
+    id: row.id,
+    title: row.title,
+    description: row.description,
+  }));
+}

--- a/application/frontend/client/const/pages/WORD_PAGE.tsx
+++ b/application/frontend/client/const/pages/WORD_PAGE.tsx
@@ -1,0 +1,7 @@
+export const WORD_PAGE: {
+  TEXT: { [key: string]: string };
+} = {
+  TEXT: {
+    heading: "語録",
+  },
+} as const;

--- a/application/frontend/client/const/type/word/WordItemType.ts
+++ b/application/frontend/client/const/type/word/WordItemType.ts
@@ -1,0 +1,5 @@
+export type WordItemType = {
+  id: number;
+  title: string;
+  description: string;
+};

--- a/supabase/migrations/003_add_word_items.sql
+++ b/supabase/migrations/003_add_word_items.sql
@@ -1,0 +1,19 @@
+-- ============================================================
+-- word_items テーブル追加
+-- ============================================================
+CREATE TABLE word_items (
+  id         integer     PRIMARY KEY,
+  title      text        NOT NULL DEFAULT '',
+  description text       NOT NULL DEFAULT ''
+);
+
+CREATE SEQUENCE IF NOT EXISTS word_items_id_seq OWNED BY word_items.id;
+ALTER TABLE word_items ALTER COLUMN id SET DEFAULT nextval('word_items_id_seq');
+
+ALTER TABLE word_items
+  ADD COLUMN updated_by uuid REFERENCES auth.users(id),
+  ADD COLUMN updated_at timestamptz;
+
+ALTER TABLE word_items ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read" ON word_items FOR SELECT USING (true);


### PR DESCRIPTION
## Summary
- 語録一覧ページ（`/word`）を新規作成し、ナビメニューに追加
- サプリメント一覧でアイテムの `notes` をインデント付き・折り返しで表示
- ハンバーガーメニューを右からスライドイン表示に変更し、行全体をクリック可能に
- `word_items` テーブルのマイグレーション追加

## Issue
Close #34

## Test plan
- [ ] `/word` ページで語録一覧が表示されること
- [ ] サプリメント画面で `notes` がアイテム名の下にインデント付きで折り返し表示されること
- [ ] ハンバーガーメニューが右からスライドインすること
- [ ] メニュー項目の行全体をタップして遷移できること
- [ ] メニューに「語録」が表示されること
- [ ] バックドロップをタップしてメニューが閉じること

🤖 Generated with [Claude Code](https://claude.com/claude-code)