### PR TITLE
E-41 client画面　語録のリッチテキスト対応

### DIFF
--- a/application/frontend/client/component/organisms/word/WordList.tsx
+++ b/application/frontend/client/component/organisms/word/WordList.tsx
@@ -34,14 +34,15 @@ export default function WordList() {
   return (
     <Box as="section" textAlign="left" width="100%">
       <style>{`
-        .word-description p { margin-bottom: 0.5em; }
-        .word-description ul, .word-description ol { padding-left: 1.5em; margin-bottom: 0.5em; }
-        .word-description strong { font-weight: bold; }
-        .word-description em { font-style: italic; }
-        .word-description h2 { font-size: 1.25em; font-weight: bold; margin-bottom: 0.5em; }
-        .word-description h3 { font-size: 1.1em; font-weight: bold; margin-bottom: 0.5em; }
-        .word-description a { color: ${STYLE_COLOR.SECONDARY}; text-decoration: underline; }
-        .word-description ruby rt { font-size: 0.5em; }
+        div.word-description p { margin-top: 0 !important; margin-bottom: 0.75em !important; white-space: pre-wrap; }
+        div.word-description p:last-child { margin-bottom: 0 !important; }
+        div.word-description ul, div.word-description ol { padding-left: 1.5em; margin-bottom: 0.75em; }
+        div.word-description strong { font-weight: bold; }
+        div.word-description em { font-style: italic; }
+        div.word-description h2 { font-size: 1.25em; font-weight: bold; margin: 0.5em 0; }
+        div.word-description h3 { font-size: 1.1em; font-weight: bold; margin: 0.5em 0; }
+        div.word-description a { color: ${STYLE_COLOR.SECONDARY}; text-decoration: underline; }
+        div.word-description ruby rt { font-size: 0.5em; }
       `}</style>
       <HeadingSecond title={WORD_PAGE.TEXT.heading} />
       {loading ? (

--- a/application/frontend/client/component/organisms/word/WordList.tsx
+++ b/application/frontend/client/component/organisms/word/WordList.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
-import { Box, Text, Spinner, SimpleGrid } from "@chakra-ui/react";
+import { Box, Spinner, Accordion } from "@chakra-ui/react";
+import { LuChevronDown } from "react-icons/lu";
 import { useErrorHandler } from "@/hooks/useErrorHandler";
 import { getWordItems } from "@/const/function/getWordItems";
 import { WORD_PAGE } from "@/const/pages/WORD_PAGE";
@@ -32,32 +33,54 @@ export default function WordList() {
 
   return (
     <Box as="section" textAlign="left" width="100%">
+      <style>{`
+        .word-description p { margin-bottom: 0.5em; }
+        .word-description ul, .word-description ol { padding-left: 1.5em; margin-bottom: 0.5em; }
+        .word-description strong { font-weight: bold; }
+        .word-description em { font-style: italic; }
+        .word-description h2 { font-size: 1.25em; font-weight: bold; margin-bottom: 0.5em; }
+        .word-description h3 { font-size: 1.1em; font-weight: bold; margin-bottom: 0.5em; }
+        .word-description a { color: ${STYLE_COLOR.SECONDARY}; text-decoration: underline; }
+        .word-description ruby rt { font-size: 0.5em; }
+      `}</style>
       <HeadingSecond title={WORD_PAGE.TEXT.heading} />
       {loading ? (
-        <Spinner />
+        <Spinner mt={4} />
       ) : (
-        <SimpleGrid gap={4} mt={4}>
+        <Accordion.Root mt={4} multiple collapsible variant="plain">
           {items.map((item) => (
-            <Box key={item.id} borderBottom={`1px solid ${STYLE_COLOR.LIGHT}`} pb={4}>
-              <Text fontWeight="bold">{item.title}</Text>
+            <Accordion.Item
+              key={item.id}
+              value={String(item.id)}
+              borderBottom={`1px solid ${STYLE_COLOR.LIGHT}`}
+            >
+              <Accordion.ItemTrigger
+                py={3}
+                fontWeight="bold"
+                color={STYLE_COLOR.BLACK}
+                _hover={{ color: STYLE_COLOR.PRIMARY }}
+                cursor={item.description ? "pointer" : "default"}
+                disabled={!item.description}
+              >
+                {item.title}
+                {item.description && (
+                  <Accordion.ItemIndicator ml="auto">
+                    <LuChevronDown />
+                  </Accordion.ItemIndicator>
+                )}
+              </Accordion.ItemTrigger>
               {item.description && (
-                <Box mt={1} color={STYLE_COLOR.BLACK} className="word-description">
-                  <style>{`
-                    .word-description p { margin-bottom: 0.5em; }
-                    .word-description ul, .word-description ol { padding-left: 1.5em; margin-bottom: 0.5em; }
-                    .word-description strong { font-weight: bold; }
-                    .word-description em { font-style: italic; }
-                    .word-description h2 { font-size: 1.25em; font-weight: bold; margin-bottom: 0.5em; }
-                    .word-description h3 { font-size: 1.1em; font-weight: bold; margin-bottom: 0.5em; }
-                    .word-description a { color: #3182ce; text-decoration: underline; }
-                    .word-description ruby rt { font-size: 0.5em; }
-                  `}</style>
-                  <div dangerouslySetInnerHTML={{ __html: item.description }} />
-                </Box>
+                <Accordion.ItemContent pb={3}>
+                  <Box
+                    color={STYLE_COLOR.BLACK}
+                    className="word-description"
+                    dangerouslySetInnerHTML={{ __html: item.description }}
+                  />
+                </Accordion.ItemContent>
               )}
-            </Box>
+            </Accordion.Item>
           ))}
-        </SimpleGrid>
+        </Accordion.Root>
       )}
     </Box>
   );

--- a/application/frontend/client/component/organisms/word/WordList.tsx
+++ b/application/frontend/client/component/organisms/word/WordList.tsx
@@ -47,30 +47,37 @@ export default function WordList() {
       {loading ? (
         <Spinner mt={4} />
       ) : (
-        <Accordion.Root mt={4} multiple collapsible variant="plain">
+        <Accordion.Root mt={4} multiple collapsible variant="plain" display="flex" flexDirection="column" gap={3}>
           {items.map((item) => (
             <Accordion.Item
               key={item.id}
               value={String(item.id)}
-              borderBottom={`1px solid ${STYLE_COLOR.LIGHT}`}
+              borderWidth="1px"
+              borderColor={STYLE_COLOR.LIGHT}
+              borderRadius="md"
+              overflow="hidden"
+              boxShadow="sm"
             >
               <Accordion.ItemTrigger
+                px={4}
                 py={3}
                 fontWeight="bold"
                 color={STYLE_COLOR.BLACK}
-                _hover={{ color: STYLE_COLOR.PRIMARY }}
+                borderLeft={`4px solid ${STYLE_COLOR.SECONDARY}`}
+                _hover={{ bg: STYLE_COLOR.LIGHT, color: STYLE_COLOR.PRIMARY }}
                 cursor={item.description ? "pointer" : "default"}
                 disabled={!item.description}
+                transition="background 0.15s"
               >
                 {item.title}
                 {item.description && (
-                  <Accordion.ItemIndicator ml="auto">
+                  <Accordion.ItemIndicator ml="auto" color={STYLE_COLOR.SECONDARY}>
                     <LuChevronDown />
                   </Accordion.ItemIndicator>
                 )}
               </Accordion.ItemTrigger>
               {item.description && (
-                <Accordion.ItemContent pb={3}>
+                <Accordion.ItemContent px={4} pt={3} pb={4} bg={STYLE_COLOR.LIGHT}>
                   <Box
                     color={STYLE_COLOR.BLACK}
                     className="word-description"


### PR DESCRIPTION
## Summary

- 語録一覧をアコーディオン（折り畳み）形式に変更
- タイトルをクリックで説明文を展開・折り畳み可能
- 複数アイテムを同時に展開可能（multiple）
- 説明文を HTML としてレンダリング（リッチテキスト・ルビ・リンク対応）
- `white-space: pre-wrap` でテキスト内の改行を正しく表示
- 説明文なしの語録はアコーディオンを無効化

## Test plan

- [ ] 語録一覧で各タイトルをクリックし展開・折り畳みが動作することを確認
- [ ] 複数の語録を同時に展開できることを確認
- [ ] 説明文内の改行・ルビ・リンクが正しく表示されることを確認
- [ ] 説明文なしの語録でトリガーが無効になっていることを確認

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)