### PR TITLE
E-47 admin 舞台/用語に種別・レギュレーション選択を追加

### DIFF
--- a/application/frontend/admin/app/[type]/[id]/page.tsx
+++ b/application/frontend/admin/app/[type]/[id]/page.tsx
@@ -47,6 +47,13 @@ export default function ItemEditPage({ params }: Props) {
           ],
         });
       }
+
+      if (type === "stage-term") {
+        const regulations = await getItems<NamedItem>("regulation");
+        setDynamicOptions({
+          regulationIds: regulations.map((r) => ({ label: r.name, value: r.id })),
+        });
+      }
     };
 
     loadDynamicOptions();

--- a/application/frontend/admin/app/api/items/route.ts
+++ b/application/frontend/admin/app/api/items/route.ts
@@ -85,6 +85,18 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ ...data, godIds, schoolIds, raceIds, supplementIds });
     }
 
+    if (type === "stage-term") {
+      const { data: itemRegs } = await supabaseAdmin
+        .from("item_regulations")
+        .select("regulation_id")
+        .eq("item_type", "stage-term")
+        .eq("item_id", id);
+
+      const regulationIds = (itemRegs ?? []).map((r) => r.regulation_id);
+
+      return NextResponse.json({ ...data, regulationIds });
+    }
+
     return NextResponse.json(data);
   }
 
@@ -167,6 +179,41 @@ export async function POST(request: NextRequest) {
     });
 
     return NextResponse.json(newReg, { status: 201 });
+  }
+
+  if (type === "stage-term") {
+    const { regulationIds, ...fields } = body;
+
+    const insertData: Record<string, unknown> = {
+      title: fields.title,
+      category: fields.category ?? "",
+      continent: fields.continent ?? "",
+      description: fields.description ?? "",
+      updated_by: user.id,
+      updated_at: now,
+    };
+
+    const { data: newItem, error } = await supabaseAdmin
+      .from(table)
+      .insert(insertData)
+      .select()
+      .single();
+
+    if (error || !newItem) {
+      return errorResponse("作成に失敗しました", "INTERNAL_ERROR", 500);
+    }
+
+    if (Array.isArray(regulationIds) && regulationIds.length > 0) {
+      await supabaseAdmin.from("item_regulations").insert(
+        regulationIds.map((regId: number) => ({
+          regulation_id: regId,
+          item_type: "stage-term",
+          item_id: newItem.id,
+        }))
+      );
+    }
+
+    return NextResponse.json(newItem, { status: 201 });
   }
 
   const insertData = buildInsertData(type, body, user.id, now);
@@ -255,6 +302,46 @@ export async function PUT(request: NextRequest) {
     return NextResponse.json({ success: true });
   }
 
+  if (type === "stage-term") {
+    const { regulationIds, ...stageTermFields } = fields;
+
+    const updateData: Record<string, unknown> = {
+      title: stageTermFields.title,
+      category: stageTermFields.category ?? "",
+      continent: stageTermFields.continent ?? "",
+      description: stageTermFields.description ?? "",
+      updated_by: user.id,
+      updated_at: now,
+    };
+
+    const { error } = await supabaseAdmin
+      .from(table)
+      .update(updateData)
+      .eq("id", id);
+
+    if (error) {
+      return errorResponse("更新に失敗しました", "INTERNAL_ERROR", 500);
+    }
+
+    await supabaseAdmin
+      .from("item_regulations")
+      .delete()
+      .eq("item_type", "stage-term")
+      .eq("item_id", id);
+
+    if (Array.isArray(regulationIds) && regulationIds.length > 0) {
+      await supabaseAdmin.from("item_regulations").insert(
+        regulationIds.map((regId: number) => ({
+          regulation_id: regId,
+          item_type: "stage-term",
+          item_id: Number(id),
+        }))
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  }
+
   const updateData = buildInsertData(type, fields, user.id, now);
   const { error } = await supabaseAdmin
     .from(table)
@@ -329,7 +416,7 @@ function buildInsertData(
     return { title: fields.title, description: fields.description ?? "", ...base };
   }
   if (type === "stage-term") {
-    return { title: fields.title, continent: fields.continent ?? "", description: fields.description ?? "", ...base };
+    return { title: fields.title, category: fields.category ?? "", continent: fields.continent ?? "", description: fields.description ?? "", ...base };
   }
   if (type === "user-role") {
     const data: Record<string, unknown> = { updated_at: now };

--- a/application/frontend/admin/component/organisms/ItemForm.tsx
+++ b/application/frontend/admin/component/organisms/ItemForm.tsx
@@ -66,6 +66,7 @@ export default function ItemForm({ formItems, form, onChange, dynamicOptions }: 
               onChange={(v) => onChange(item.column, v)}
               options={options}
               required={item.rule?.required}
+              placeholder={item.placeholder}
             />
           );
         }

--- a/application/frontend/admin/const/config/stageTerm.ts
+++ b/application/frontend/admin/const/config/stageTerm.ts
@@ -14,6 +14,16 @@ const CONTINENT_LABEL: Record<string, string> = {
   reseldawn: "レーゼルドーン",
 };
 
+const CATEGORY_OPTIONS = [
+  { label: "舞台", value: "stage" },
+  { label: "NPC", value: "npc" },
+] as const;
+
+const CATEGORY_LABEL: Record<string, string> = {
+  stage: "舞台",
+  npc: "NPC",
+};
+
 export const stageTermConfig: EntityConfigType = {
   apiType: "stage-term",
   listTitle: "舞台/用語管理",
@@ -22,27 +32,45 @@ export const stageTermConfig: EntityConfigType = {
   deleteConfirm: "この舞台/用語を削除しますか？",
   initialForm: {
     title: "",
+    category: "",
     continent: "",
     description: "",
+    regulationIds: [],
   },
   columns: [
-    { key: "id", label: "ID" },
     { key: "title", label: "タイトル" },
+    {
+      key: "category",
+      label: "種別",
+      render: (v) => CATEGORY_LABEL[String(v)] ?? String(v ?? ""),
+    },
     {
       key: "continent",
       label: "大陸",
       render: (v) => CONTINENT_LABEL[String(v)] ?? String(v ?? ""),
     },
   ],
+  spColumns: [
+    { key: "title", label: "タイトル" },
+    {
+      key: "category",
+      label: "種別",
+      render: (v) => CATEGORY_LABEL[String(v)] ?? String(v ?? ""),
+    },
+  ],
   formItems: [
     { column: "title", label: "タイトル", type: "text", rule: { required: true } },
-    { column: "continent", label: "大陸", type: "select", rule: { required: true }, option: CONTINENT_OPTIONS },
+    { column: "category", label: "種別", type: "select", rule: { required: true }, option: CATEGORY_OPTIONS, placeholder: "選択してください" },
+    { column: "continent", label: "大陸", type: "select", rule: { required: true }, option: CONTINENT_OPTIONS, placeholder: "選択してください" },
     { column: "description", label: "内容", type: "rich-text" },
+    { column: "regulationIds", label: "レギュレーション", type: "checkbox-group" },
   ],
   toForm: (data) => ({
     title: data.title,
+    category: data.category ?? "",
     continent: data.continent ?? "",
     description: data.description ?? "",
+    regulationIds: data.regulationIds ?? [],
   }),
   toBody: (form) => form,
 };

--- a/application/frontend/admin/const/type/form/FormItemType.ts
+++ b/application/frontend/admin/const/type/form/FormItemType.ts
@@ -8,4 +8,5 @@ export type FormItemType = {
     pattern?: string;
   };
   option?: readonly { label: string; value: string | number }[];
+  placeholder?: string;
 };

--- a/supabase/migrations/005_add_stage_term_category.sql
+++ b/supabase/migrations/005_add_stage_term_category.sql
@@ -1,0 +1,22 @@
+-- ============================================================
+-- stage_term_items: category カラム追加
+-- ============================================================
+ALTER TABLE stage_term_items
+  ADD COLUMN IF NOT EXISTS category text NOT NULL DEFAULT '';
+
+-- ============================================================
+-- item_regulations: item_type_check に 'stage-term' を追加
+-- ============================================================
+ALTER TABLE item_regulations
+  DROP CONSTRAINT IF EXISTS item_regulations_item_type_check;
+
+ALTER TABLE item_regulations
+  ADD CONSTRAINT item_regulations_item_type_check
+    CHECK (item_type IN ('god', 'school', 'race', 'supplement', 'stage-term'));
+
+-- stage_term_items 削除時に item_regulations を CASCADE 削除するトリガー
+DROP TRIGGER IF EXISTS trg_stage_term_items_delete ON stage_term_items;
+
+CREATE TRIGGER trg_stage_term_items_delete
+  AFTER DELETE ON stage_term_items FOR EACH ROW
+  EXECUTE FUNCTION delete_item_regulations_on_item_delete('stage-term');


### PR DESCRIPTION
## Summary
- 舞台/用語フォームに種別（舞台/NPC）セレクトを追加
- 舞台/用語フォームにレギュレーション複数選択（チェックボックスグループ）を追加
- 一覧画面から ID カラムを削除、SP版では大陸カラムを非表示化

## Issue
Close #47

## Test plan
- [ ] 舞台/用語の新規作成で種別・大陸・レギュレーションが保存されること
- [ ] 舞台/用語の編集で種別・大陸・レギュレーションが正しく読み込まれること
- [ ] レギュレーションを複数選択して保存・再編集で反映されること
- [ ] 一覧画面に ID カラムが表示されないこと
- [ ] SP表示で大陸カラムが表示されないこと
- [ ] マイグレーション 005 が正常に適用されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)