### PR TITLE
E-56 admin レギュレーション編集画面にスケジュール日程設定を追加

### DIFF
--- a/.claude/rules/CODING_STANDARDS.md
+++ b/.claude/rules/CODING_STANDARDS.md
@@ -531,7 +531,38 @@ useEffect(() => {
 
 ---
 
-## 12. チェックリスト
+## 12. `any` / `unknown` の禁止
+
+`any` と `unknown` は **絶対に使用しない**。型が合わない場合は型定義を修正して根本解決すること。
+
+### 禁止される対応
+
+```typescript
+// ❌ unknown を経由した強制キャスト
+const items = data.items as unknown as MyType[];
+
+// ❌ any で型チェックを回避
+const value: any = data.field;
+```
+
+### 根本的な解決の例
+
+JSONB フィールドの型が合わない場合は `RowValue` / `FormRecord` に `Record<string, string | number | boolean | null>[]` を追加し、`Array.isArray` でランタイムチェックしてから各フィールドをマッピングする。
+
+```typescript
+// ✅ 型を拡張してランタイムチェック
+levelCapSchedule: Array.isArray(data.level_cap_schedule)
+  ? (data.level_cap_schedule as Record<string, string | number | boolean | null>[]).map((item) => ({
+      levelCapId: item.levelCapId as number,
+      level: item.level as string,
+      date: item.date as string,
+    }))
+  : [],
+```
+
+---
+
+## 13. チェックリスト
 
 新しいコードを書く際は、以下を確認してください。
 
@@ -547,3 +578,4 @@ useEffect(() => {
 - [ ] コンポーネントの return 文は1つだけか
 - [ ] エラー処理は `useErrorHandler` を使用しているか
 - [ ] `let ignore` パターンを使用していないか
+- [ ] `any` / `unknown` を使用していないか

--- a/application/frontend/admin/app/api/items/route.ts
+++ b/application/frontend/admin/app/api/items/route.ts
@@ -156,6 +156,11 @@ export async function POST(request: NextRequest) {
       notes: fields.notes ?? "",
       level_cap_belt: fields.levelCapBelt,
       publish_type: fields.publishType ?? "draft",
+      char_creation_start_date: fields.charCreationStartDate || null,
+      level_cap_start_date: (fields.levelCapSchedule as { date?: string }[])?.[0]?.date || null,
+      epilogue_start_date: fields.epilogueStartDate || null,
+      epilogue_end_date: fields.epilogueEndDate || null,
+      level_cap_schedule: fields.levelCapSchedule ?? [],
       updated_by: user.id,
       updated_at: now,
     };
@@ -278,6 +283,11 @@ export async function PUT(request: NextRequest) {
       notes: regulationFields.notes ?? "",
       level_cap_belt: regulationFields.levelCapBelt,
       publish_type: regulationFields.publishType,
+      char_creation_start_date: regulationFields.charCreationStartDate || null,
+      level_cap_start_date: (regulationFields.levelCapSchedule as { date?: string }[])?.[0]?.date || null,
+      epilogue_start_date: regulationFields.epilogueStartDate || null,
+      epilogue_end_date: regulationFields.epilogueEndDate || null,
+      level_cap_schedule: regulationFields.levelCapSchedule ?? [],
       updated_by: user.id,
       updated_at: now,
     };

--- a/application/frontend/admin/app/api/level-cap/route.ts
+++ b/application/frontend/admin/app/api/level-cap/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { createServerClient } from "@supabase/ssr";
+
+type ErrorResponse = {
+  error: string;
+  code: string;
+};
+
+const errorResponse = (error: string, code: string, status: number) =>
+  NextResponse.json<ErrorResponse>({ error, code }, { status });
+
+async function getAuthenticatedUser(request: NextRequest) {
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll: () => request.cookies.getAll(),
+        setAll: () => {},
+      },
+    }
+  );
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const { data: userMeta } = await supabaseAdmin
+    .from("user_meta")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  if (userMeta?.role !== "admin") return null;
+  return user;
+}
+
+export async function GET(request: NextRequest) {
+  const user = await getAuthenticatedUser(request);
+  if (!user) return errorResponse("権限がありません", "FORBIDDEN", 403);
+
+  const { searchParams } = new URL(request.url);
+  const belt = searchParams.get("belt");
+
+  if (belt !== "B" && belt !== "C") {
+    return errorResponse("beltパラメータが不正です", "BAD_REQUEST", 400);
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("level_cap")
+    .select("id, level")
+    .eq("belt_type", belt)
+    .order("sort_order", { ascending: true });
+
+  if (error) return errorResponse("データ取得に失敗しました", "INTERNAL_ERROR", 500);
+
+  return NextResponse.json(data as { id: number; level: string }[]);
+}

--- a/application/frontend/admin/component/molecules/field/DateInputField.tsx
+++ b/application/frontend/admin/component/molecules/field/DateInputField.tsx
@@ -1,0 +1,27 @@
+"use client";
+import { HStack, Field } from "@chakra-ui/react";
+
+type Props = {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  required?: boolean;
+};
+
+export default function DateInputField({ label, value, onChange, required }: Props) {
+  return (
+    <Field.Root required={required}>
+      <HStack align="center" gap={3}>
+        <Field.Label whiteSpace="nowrap" mb={0}>
+          {label}
+          {required && <Field.RequiredIndicator />}
+        </Field.Label>
+        <input
+          type="date"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      </HStack>
+    </Field.Root>
+  );
+}

--- a/application/frontend/admin/component/molecules/field/EpiloguePeriodField.tsx
+++ b/application/frontend/admin/component/molecules/field/EpiloguePeriodField.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { Stack, Box, Text } from "@chakra-ui/react";
+import DateInputField from "@/component/molecules/field/DateInputField";
+
+type Props = {
+  startDate: string;
+  endDate: string;
+  onStartChange: (value: string) => void;
+  onEndChange: (value: string) => void;
+};
+
+export default function EpiloguePeriodField({ startDate, endDate, onStartChange, onEndChange }: Props) {
+  return (
+    <Box>
+      <Text fontWeight="medium" mb={2}>エピローグ期間</Text>
+      <Stack direction={{ base: "column", md: "row" }} gap={3} align={{ base: "stretch", md: "center" }} width="fit-content">
+        <DateInputField label="開始日" value={startDate} onChange={onStartChange} />
+        <DateInputField label="終了日" value={endDate} onChange={onEndChange} />
+      </Stack>
+    </Box>
+  );
+}

--- a/application/frontend/admin/component/molecules/field/LevelCapScheduleSection.tsx
+++ b/application/frontend/admin/component/molecules/field/LevelCapScheduleSection.tsx
@@ -1,0 +1,185 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import { Box, VStack, Text, HStack, Input, Field, Button } from "@chakra-ui/react";
+import DateInputField from "@/component/molecules/field/DateInputField";
+import SelectRadioField from "@/component/molecules/field/SelectRadioField";
+import { useErrorHandler } from "@/hooks/useErrorHandler";
+import type { LevelCapScheduleItem } from "@/const/type/config/EntityConfigType";
+
+type Props = {
+  label: string;
+  belt: string;
+  values: LevelCapScheduleItem[];
+  onChange: (values: LevelCapScheduleItem[]) => void;
+  epilogueStartDate?: string;
+};
+
+export default function LevelCapScheduleSection({ label, belt, values, onChange, epilogueStartDate }: Props) {
+  const [rows, setRows] = useState<LevelCapScheduleItem[]>([]);
+  const [isManual, setIsManual] = useState(false);
+  const [interval, setInterval] = useState(15);
+  const { handleError } = useErrorHandler();
+  const isFirstMountRef = useRef(true);
+  const valuesRef = useRef<LevelCapScheduleItem[]>(values);
+
+  useEffect(() => {
+    valuesRef.current = values;
+    const hasSavedDates = values.some((v) => v.date);
+    if (hasSavedDates) setIsManual(true);
+  }, [values]);
+
+  // ベルト変更時: レベル一覧を取得し、保存済みデータがあればマージ
+  useEffect(() => {
+    const fetchAndBuild = async () => {
+      try {
+        const res = await fetch(`/api/level-cap?belt=${belt}`);
+        const levels: { id: number; level: string }[] = await res.json();
+        const saved = valuesRef.current;
+        const merged = levels.map((lv) => {
+          const s = saved.find((v) => v.levelCapId === lv.id);
+          return { levelCapId: lv.id, level: lv.level, date: s?.date ?? "" };
+        });
+        setRows(merged);
+        if (!isFirstMountRef.current) {
+          onChange(merged);
+        }
+        isFirstMountRef.current = false;
+      } catch (err) {
+        handleError(err);
+      }
+    };
+    fetchAndBuild();
+  }, [belt]);
+
+  // 親が非同期でDB値をロードした後（ベルトfetch完了後）にマージ
+  useEffect(() => {
+    if (values.length === 0) return;
+    setRows((prev) => {
+      if (prev.length === 0) return prev;
+      const needsUpdate = values.some((v) => {
+        const row = prev.find((r) => r.levelCapId === v.levelCapId);
+        return row && v.date && row.date !== v.date;
+      });
+      if (!needsUpdate) return prev;
+      return prev.map((row) => {
+        const saved = values.find((v) => v.levelCapId === row.levelCapId);
+        return saved?.date ? { ...row, date: saved.date } : row;
+      });
+    });
+  }, [values]);
+
+  const handleDateChange = (levelCapId: number, date: string) => {
+    const updatedRows = rows.map((row) =>
+      row.levelCapId === levelCapId ? { ...row, date } : row
+    );
+
+    const firstRow = updatedRows[0];
+    if (firstRow.levelCapId === levelCapId && date) {
+      const addDays = (dateStr: string, days: number): string => {
+        const d = new Date(dateStr);
+        d.setDate(d.getDate() + days);
+        return d.toISOString().slice(0, 10);
+      };
+      const autoFilled = updatedRows.map((row, index) =>
+        index === 0 || row.date ? row : { ...row, date: addDays(date, index * interval) }
+      );
+      setRows(autoFilled);
+      onChange(autoFilled);
+      return;
+    }
+
+    setRows(updatedRows);
+    onChange(updatedRows);
+  };
+
+  const lastDate = rows.length > 0 ? rows[rows.length - 1].date : "";
+  const levelCapEndDate = (() => {
+    if (epilogueStartDate) {
+      const d = new Date(epilogueStartDate);
+      d.setDate(d.getDate() - 1);
+      return d.toISOString().slice(0, 10);
+    }
+    if (!lastDate) return "";
+    const d = new Date(lastDate);
+    d.setDate(d.getDate() + interval);
+    return d.toISOString().slice(0, 10);
+  })();
+
+  return (
+    <Box>
+      {rows[0] && (
+        <Box>
+          <DateInputField
+            label="レベルキャップ開始日"
+            value={rows[0].date}
+            onChange={(value) => handleDateChange(rows[0].levelCapId, value)}
+          />
+          {levelCapEndDate && (
+            <Text fontSize="sm" color="fg.muted" mt={1}>
+              レベルキャップ終了日: {levelCapEndDate}
+            </Text>
+          )}
+          <HStack mt={2} align="center">
+            <Text fontSize="sm" whiteSpace="nowrap">手動変更</Text>
+            <SelectRadioField
+              options={[
+                { label: "する", value: "manual" },
+                { label: "しない", value: "auto" },
+              ]}
+              value={isManual ? "manual" : "auto"}
+              onChange={(v) => setIsManual(v === "manual")}
+            />
+            <HStack align="center" gap={1}>
+              <Text fontSize="sm" whiteSpace="nowrap">間隔</Text>
+              <Input
+                type="number"
+                value={interval}
+                onChange={(e) => setInterval(Number(e.target.value))}
+                min={1}
+                w="60px"
+                size="sm"
+              />
+              <Text fontSize="sm" color="fg.muted">日</Text>
+            </HStack>
+          </HStack>
+        </Box>
+      )}
+      {isManual && rows.length > 0 && (
+        <VStack gap={3} pt={3} align="stretch">
+          <Button
+            size="sm"
+            variant="outline"
+            colorPalette="red"
+            alignSelf="flex-start"
+            disabled={rows.every((r) => !r.date)}
+            onClick={() => {
+              const startDate = rows[0]?.date;
+              if (!startDate) return;
+              const addDays = (dateStr: string, days: number): string => {
+                const d = new Date(dateStr);
+                d.setDate(d.getDate() + days);
+                return d.toISOString().slice(0, 10);
+              };
+              const recalculated = rows.map((row, index) => ({
+                ...row,
+                date: addDays(startDate, index * interval),
+              }));
+              setRows(recalculated);
+              onChange(recalculated);
+            }}
+          >
+            リセット
+          </Button>
+          {rows.map((row) => (
+            <DateInputField
+              key={row.levelCapId}
+              label={`Lv. ${row.level}`}
+              value={row.date}
+              onChange={(value) => handleDateChange(row.levelCapId, value)}
+            />
+          ))}
+        </VStack>
+      )}
+    </Box>
+  );
+}

--- a/application/frontend/admin/component/molecules/field/SelectRadioField.tsx
+++ b/application/frontend/admin/component/molecules/field/SelectRadioField.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { HStack, Button } from "@chakra-ui/react";
+
+type Option = { label: string; value: string };
+
+type Props = {
+  options: Option[];
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export default function SelectRadioField({ options, value, onChange }: Props) {
+  return (
+    <HStack gap={0}>
+      {options.map((opt, index) => (
+        <Button
+          key={opt.value}
+          onClick={() => onChange(opt.value)}
+          colorPalette="blue"
+          variant={value === opt.value ? "solid" : "outline"}
+          borderRadius={0}
+          borderLeftRadius={index === 0 ? "md" : 0}
+          borderRightRadius={index === options.length - 1 ? "md" : 0}
+          size="sm"
+        >
+          {opt.label}
+        </Button>
+      ))}
+    </HStack>
+  );
+}

--- a/application/frontend/admin/component/organisms/ItemForm.tsx
+++ b/application/frontend/admin/component/organisms/ItemForm.tsx
@@ -1,13 +1,16 @@
 "use client";
-import { VStack } from "@chakra-ui/react";
+import { VStack, Box, Text, Separator } from "@chakra-ui/react";
 import TextInputField from "@/component/molecules/field/TextInputField";
 import TextareaField from "@/component/molecules/field/TextareaField";
 import RichTextField from "@/component/molecules/field/RichTextField";
 import SelectField from "@/component/molecules/field/SelectField";
 import CheckboxField from "@/component/molecules/field/CheckboxField";
 import CheckboxGroupField from "@/component/molecules/field/CheckboxGroupField";
+import DateInputField from "@/component/molecules/field/DateInputField";
+import LevelCapScheduleSection from "@/component/molecules/field/LevelCapScheduleSection";
+import EpiloguePeriodField from "@/component/molecules/field/EpiloguePeriodField";
 import type { FormItemType } from "@/const/type/form/FormItemType";
-import type { FormRecord } from "@/const/type/config/EntityConfigType";
+import type { FormRecord, LevelCapScheduleItem } from "@/const/type/config/EntityConfigType";
 
 type Props = {
   formItems: FormItemType[];
@@ -91,6 +94,54 @@ export default function ItemForm({ formItems, form, onChange, dynamicOptions }: 
             />
           );
         }
+        if (item.type === "date") {
+          return (
+            <DateInputField
+              key={item.column}
+              label={item.label}
+              value={String(form[item.column] ?? "")}
+              onChange={(v) => onChange(item.column, v)}
+              required={item.rule?.required}
+            />
+          );
+        }
+
+        if (item.type === "level-cap-schedule") {
+          return (
+            <LevelCapScheduleSection
+              key={item.column}
+              label={item.label}
+              belt={String(form["levelCapBelt"] ?? "B")}
+              values={(form[item.column] as LevelCapScheduleItem[]) ?? []}
+              onChange={(v) => onChange(item.column, v)}
+              epilogueStartDate={String(form["epilogueStartDate"] ?? "")}
+            />
+          );
+        }
+
+        if (item.type === "epilogue-period") {
+          return (
+            <EpiloguePeriodField
+              key={item.column}
+              startDate={String(form["epilogueStartDate"] ?? "")}
+              endDate={String(form["epilogueEndDate"] ?? "")}
+              onStartChange={(v) => onChange("epilogueStartDate", v)}
+              onEndChange={(v) => onChange("epilogueEndDate", v)}
+            />
+          );
+        }
+
+        if (item.type === "section-heading") {
+          return (
+            <Box key={item.column} pt={4} pb={1}>
+              <Separator />
+              <Text fontWeight="bold" mt={3} fontSize="sm" color="gray.600">
+                {item.label}
+              </Text>
+            </Box>
+          );
+        }
+
         return null;
       })}
     </VStack>

--- a/application/frontend/admin/const/config/regulation.ts
+++ b/application/frontend/admin/const/config/regulation.ts
@@ -77,7 +77,13 @@ export const regulationConfig: EntityConfigType = {
     charCreationStartDate: (data.char_creation_start_date as string) ?? "",
     epilogueStartDate: (data.epilogue_start_date as string) ?? "",
     epilogueEndDate: (data.epilogue_end_date as string) ?? "",
-    levelCapSchedule: (data.level_cap_schedule as unknown as LevelCapScheduleItem[]) ?? [],
+    levelCapSchedule: Array.isArray(data.level_cap_schedule)
+      ? (data.level_cap_schedule as Record<string, string | number | boolean | null>[]).map((item) => ({
+          levelCapId: item.levelCapId as number,
+          level: item.level as string,
+          date: item.date as string,
+        }))
+      : [],
     godIds: data.godIds ?? [],
     schoolIds: data.schoolIds ?? [],
     raceIds: data.raceIds ?? [],

--- a/application/frontend/admin/const/config/regulation.ts
+++ b/application/frontend/admin/const/config/regulation.ts
@@ -1,4 +1,4 @@
-import type { EntityConfigType } from "@/const/type/config/EntityConfigType";
+import type { EntityConfigType, LevelCapScheduleItem } from "@/const/type/config/EntityConfigType";
 
 export const regulationConfig: EntityConfigType = {
   apiType: "regulation",
@@ -12,6 +12,10 @@ export const regulationConfig: EntityConfigType = {
     recruitment: "",
     stage: "",
     levelCapBelt: "B",
+    charCreationStartDate: "",
+    epilogueStartDate: "",
+    epilogueEndDate: "",
+    levelCapSchedule: [],
     publishType: "draft",
     godIds: [],
     schoolIds: [],
@@ -58,6 +62,10 @@ export const regulationConfig: EntityConfigType = {
     { column: "raceIds", label: "使用可能種族", type: "checkbox-group" },
     { column: "supplementIds", label: "使用可能サプリメント", type: "checkbox-group" },
     { column: "notes", label: "備考", type: "textarea" },
+    { column: "_schedule", label: "スケジュール", type: "section-heading" },
+    { column: "charCreationStartDate", label: "キャラ作成開始日", type: "date" },
+    { column: "levelCapSchedule", label: "レベルキャップ日程", type: "level-cap-schedule" },
+    { column: "epilogueStartDate", label: "エピローグ期間", type: "epilogue-period" },
   ],
   toForm: (data) => ({
     publishType: data.publish_type,
@@ -66,6 +74,10 @@ export const regulationConfig: EntityConfigType = {
     recruitment: data.recruitment,
     stage: data.stage,
     levelCapBelt: data.level_cap_belt,
+    charCreationStartDate: (data.char_creation_start_date as string) ?? "",
+    epilogueStartDate: (data.epilogue_start_date as string) ?? "",
+    epilogueEndDate: (data.epilogue_end_date as string) ?? "",
+    levelCapSchedule: (data.level_cap_schedule as LevelCapScheduleItem[]) ?? [],
     godIds: data.godIds ?? [],
     schoolIds: data.schoolIds ?? [],
     raceIds: data.raceIds ?? [],

--- a/application/frontend/admin/const/config/regulation.ts
+++ b/application/frontend/admin/const/config/regulation.ts
@@ -77,7 +77,7 @@ export const regulationConfig: EntityConfigType = {
     charCreationStartDate: (data.char_creation_start_date as string) ?? "",
     epilogueStartDate: (data.epilogue_start_date as string) ?? "",
     epilogueEndDate: (data.epilogue_end_date as string) ?? "",
-    levelCapSchedule: (data.level_cap_schedule as LevelCapScheduleItem[]) ?? [],
+    levelCapSchedule: (data.level_cap_schedule as unknown as LevelCapScheduleItem[]) ?? [],
     godIds: data.godIds ?? [],
     schoolIds: data.schoolIds ?? [],
     raceIds: data.raceIds ?? [],

--- a/application/frontend/admin/const/type/config/EntityConfigType.ts
+++ b/application/frontend/admin/const/type/config/EntityConfigType.ts
@@ -16,6 +16,7 @@ export type FormRecord = Record<
   | number[]
   | (string | number)[]
   | Record<string, string | number | boolean | null>
+  | Record<string, string | number | boolean | null>[]
   | LevelCapScheduleItem[]
   | null
 >;

--- a/application/frontend/admin/const/type/config/EntityConfigType.ts
+++ b/application/frontend/admin/const/type/config/EntityConfigType.ts
@@ -1,7 +1,24 @@
 import type { TableColumnType, TableRow } from "@/const/type/table/TableColumnType";
 import type { FormItemType } from "@/const/type/form/FormItemType";
 
-export type FormRecord = Record<string, string | number | boolean | string[] | number[] | (string | number)[] | Record<string, string | number | boolean | null> | null>;
+export type LevelCapScheduleItem = {
+  levelCapId: number;
+  level: string;
+  date: string;
+};
+
+export type FormRecord = Record<
+  string,
+  | string
+  | number
+  | boolean
+  | string[]
+  | number[]
+  | (string | number)[]
+  | Record<string, string | number | boolean | null>
+  | LevelCapScheduleItem[]
+  | null
+>;
 
 export type EntityConfigType = {
   apiType: string;

--- a/application/frontend/admin/const/type/form/FormItemType.ts
+++ b/application/frontend/admin/const/type/form/FormItemType.ts
@@ -1,7 +1,7 @@
 export type FormItemType = {
   column: string;
   label: string;
-  type: "text" | "textarea" | "rich-text" | "password" | "number" | "checkbox" | "checkbox-group" | "select";
+  type: "text" | "textarea" | "rich-text" | "password" | "number" | "checkbox" | "checkbox-group" | "select" | "date" | "level-cap-schedule" | "epilogue-period" | "section-heading";
   rule?: {
     required?: boolean;
     minLength?: number;

--- a/application/frontend/admin/const/type/table/TableColumnType.ts
+++ b/application/frontend/admin/const/type/table/TableColumnType.ts
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-export type RowValue = string | number | boolean | null | string[] | number[] | Record<string, string | number | boolean | null>;
+export type RowValue = string | number | boolean | null | string[] | number[] | Record<string, string | number | boolean | null> | Record<string, string | number | boolean | null>[];
 export type TableRow = Record<string, RowValue>;
 
 export type TableColumnType = {

--- a/docs/admin/design/02_regulation.md
+++ b/docs/admin/design/02_regulation.md
@@ -21,6 +21,10 @@
 | supplement | text | サプリメントに関する自由記述テキスト（`item_regulations` の `supplementIds` による紐付けとは独立した補足説明欄） |
 | notes | text | 備考 |
 | level_cap_belt | text | レベルキャップ・ベルト情報（"B" = 標準キャップ / "C" = 上限解放キャップ。必須。CHECK制約あり） |
+| char_creation_start_date | date (nullable) | キャラ作成開始日 |
+| level_cap_start_date | date (nullable) | レベルキャップ開始日（Lv.2の日付） |
+| epilogue_end_date | date (nullable) | エピローグ終了日 |
+| level_cap_schedule | jsonb | レベルキャップ日程（`[{"levelCapId":number,"level":string,"date":"YYYY-MM-DD"}]`）。デフォルト: `[]` |
 | publish_type | text | 公開状態（"public"=公開 / "draft"=下書き） |
 | updated_by | uuid (nullable) | 最終更新者ID（auth.users.id） |
 | updated_at | timestamptz (nullable) | 最終更新日時 |
@@ -108,11 +112,23 @@ component/
 | supplement | `TextareaField` | - |
 | notes | `TextareaField` | - |
 | level_cap_belt | `SelectField` | 必須（B / C） |
+| char_creation_start_date | `DateInputField` | - |
+| level_cap_start_date | `DateInputField` | - |
+| level_cap_schedule | `LevelCapScheduleSection` | - |
+| epilogue_end_date | `DateInputField` | - |
 | publish_type | `SelectField` | 必須（"public"=公開 / "draft"=下書き）デフォルト: "draft"。公開後も自由に変更可 |
 | 使用可能神格 | `CheckboxGroupField` | `is_always = false` の god_items を選択肢に表示 |
 | 使用可能流派 | `CheckboxGroupField` | `is_always = false` の school_items を選択肢に表示 |
 | 使用可能種族 | `CheckboxGroupField` | `is_always = false` の race_items を選択肢に表示 |
 | 使用可能サプリメント | `CheckboxGroupField` | `is_always = false` の supplement_items を選択肢に表示 |
+
+### LevelCapScheduleSection の動作仕様
+
+- `levelCapStartDate` が入力されると `/api/level-cap?belt=X` を呼び出し、選択ベルトの全レベルを取得する
+- `levelCapStartDate` を起点に15日間隔で各レベルの日付を自動生成して表示する
+- 保存済みの日程がある場合は自動計算より保存済み日付を優先して表示する
+- 各行は `DateInputField` で個別に手動変更可能
+- `levelCapStartDate` が空のときはセクションを非表示にする
 
 ### CheckboxGroupField の動作仕様
 
@@ -258,6 +274,15 @@ export const REGULATION_FORM_ITEM: { [key: string]: FormItemType } = {
 ---
 
 ## 型定義
+
+```typescript
+// const/type/config/EntityConfigType.ts
+export type LevelCapScheduleItem = {
+  levelCapId: number;
+  level: string;
+  date: string; // "YYYY-MM-DD"
+};
+```
 
 ```typescript
 // const/type/regulation/RegulationFormType.ts

--- a/supabase/migrations/009_add_regulation_schedule.sql
+++ b/supabase/migrations/009_add_regulation_schedule.sql
@@ -1,0 +1,6 @@
+ALTER TABLE regulation_items
+  ADD COLUMN IF NOT EXISTS char_creation_start_date date,
+  ADD COLUMN IF NOT EXISTS level_cap_start_date     date,
+  ADD COLUMN IF NOT EXISTS epilogue_start_date      date,
+  ADD COLUMN IF NOT EXISTS epilogue_end_date        date,
+  ADD COLUMN IF NOT EXISTS level_cap_schedule       jsonb NOT NULL DEFAULT '[]';


### PR DESCRIPTION
## Summary

- レギュレーション編集画面にスケジュールセクションを追加（キャラ作成開始日・レベルキャップ日程・エピローグ期間）
- レベルキャップ開始日を起点に間隔日数で各レベルの日付を自動生成、手動変更も可能
- エピローグ開始日がある場合はその前日、ない場合は間隔日数でレベルキャップ終了日を自動算出
- 保存済みデータがある場合は編集画面で手動変更モードで自動表示

## Test plan

- [ ] 新規レギュレーション作成: レベルキャップ開始日を入力 → 各レベルの日付が自動生成されること
- [ ] 手動変更「する」で各レベルの日付が編集できること
- [ ] リセットボタンで間隔日数から再計算されること
- [ ] エピローグ開始日を設定するとレベルキャップ終了日がその前日になること
- [ ] 保存後に編集画面を開くと日程が正しく表示されること
- [ ] supabase migration 009 を適用して `level_cap_start_date` カラムが追加されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)