### PR TITLE
E-45 マイページ・ログイン機能を追加

### DIFF
--- a/application/frontend/client/app/api/auth/route.ts
+++ b/application/frontend/client/app/api/auth/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { LOGIN } from "@/const/pages/LOGIN";
+import type { UserRoleType } from "@/const/type/auth/UserRoleType";
+
+// 内部メールドメイン。admin と共通の user_meta を用いるため admin と同一ドメインを使う。
+const INTERNAL_EMAIL_DOMAIN = "eagle-admin.internal";
+
+// ユーザー列挙対策のタイミング平準化用ダミー値。
+// user_id 不存在時もこのダミー資格情報で signInWithPassword を実行し、
+// Auth 呼び出し相当の処理を通して応答時間差を抑える（必ず失敗するメール）。
+const DUMMY_EMAIL = `timing-equalizer@${INTERNAL_EMAIL_DOMAIN}`;
+const DUMMY_PASSWORD = "timing-equalizer-dummy-password";
+
+type LoginBody = {
+  action: string;
+  userId: string;
+  password: string;
+};
+
+type UserMetaRow = {
+  id: string;
+  user_id: string;
+  role: UserRoleType | null;
+};
+
+// ユーザー列挙対策: user_id 不存在・パスワード誤りのいずれも同一の 401 を返す。
+function unauthorizedResponse(): NextResponse {
+  return NextResponse.json(
+    { error: LOGIN.TEXT.ERROR_INVALID, code: "UNAUTHORIZED" },
+    { status: 401 }
+  );
+}
+
+// エラー秘匿: 内部エラー詳細・スタックはレスポンスに含めない。
+function internalErrorResponse(): NextResponse {
+  return NextResponse.json(
+    { error: "サーバーエラーが発生しました", code: "INTERNAL_ERROR" },
+    { status: 500 }
+  );
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as Partial<LoginBody>;
+    const action = body.action;
+
+    // action が "login" 以外は 400。
+    if (action !== "login") {
+      return NextResponse.json(
+        { error: "不正なリクエストです", code: "BAD_REQUEST" },
+        { status: 400 }
+      );
+    }
+
+    const userId = typeof body.userId === "string" ? body.userId : "";
+    const password = typeof body.password === "string" ? body.password : "";
+
+    if (userId === "" || password === "") {
+      return NextResponse.json(
+        { error: "不正なリクエストです", code: "BAD_REQUEST" },
+        { status: 400 }
+      );
+    }
+
+    // user_id → ユーザー解決は supabaseAdmin（Service Role）で行う。
+    // 未認証リクエストは anon key では RLS により user_meta を読めないため、必ず Service Role を使う。
+    const { data: userMeta, error: metaError } = await supabaseAdmin
+      .from("user_meta")
+      .select("id, user_id, role")
+      .eq("user_id", userId)
+      .single<UserMetaRow>();
+
+    // Cookie 反映用のレスポンス。@supabase/ssr が成功時にセッション Cookie を載せる。
+    // Cookie 属性（HttpOnly / Secure / SameSite）は @supabase/ssr のデフォルトに従う（S-3）。
+    const response = NextResponse.json({ role: userMeta?.role ?? null });
+
+    const supabaseSSR = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll: () => request.cookies.getAll(),
+          setAll: (cookiesToSet) => {
+            cookiesToSet.forEach(({ name, value, options }) => {
+              response.cookies.set(name, value, options);
+            });
+          },
+        },
+      }
+    );
+
+    // タイミング平準化: user_id 不存在時もダミー資格情報で signInWithPassword を実行し、
+    // Auth 呼び出し相当の処理を必ず通すことで応答時間差からのユーザー存在推測を防ぐ（S-4）。
+    if (metaError || !userMeta) {
+      await supabaseSSR.auth.signInWithPassword({
+        email: DUMMY_EMAIL,
+        password: DUMMY_PASSWORD,
+      });
+      return unauthorizedResponse();
+    }
+
+    // email を {userId}@eagle-admin.internal で組み立て、セッション Cookie を発行する。
+    const email = `${userId}@${INTERNAL_EMAIL_DOMAIN}`;
+    const { error: signInError } = await supabaseSSR.auth.signInWithPassword({
+      email,
+      password,
+    });
+
+    // パスワード誤り等のサインイン失敗は user_id 不存在と同一の 401 に統一する。
+    if (signInError) {
+      return unauthorizedResponse();
+    }
+
+    // 成功 → user_meta.role を 200 で返す。
+    // role が "common" でもセッションは発行し 200 + role を返す（アクセス制御は middleware と遷移先で行う）。
+    return response;
+  } catch {
+    // 内部エラー詳細・スタックはレスポンスに含めない。
+    return internalErrorResponse();
+  }
+}

--- a/application/frontend/client/app/api/mypage/route.ts
+++ b/application/frontend/client/app/api/mypage/route.ts
@@ -1,0 +1,226 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+import { validateYutosheetUrl } from "@/const/function/validateYutosheetUrl";
+import { getScheduledRegulations } from "@/const/function/getScheduledRegulations";
+import type { UserRegulationSheetType } from "@/const/type/mypage/UserRegulationSheetType";
+import type { UserRoleType } from "@/const/type/auth/UserRoleType";
+
+// マイページ機能の認可は user_meta.role の allowlist（フェイルクローズ）で行う。
+// general / admin に厳密一致した場合のみ許可し、それ以外（common / null / 未知 / 取得失敗 / 例外）は全拒否する。
+const ALLOWED_ROLES: readonly UserRoleType[] = ["general", "admin"];
+
+// 入力検証の上限（設計 S-4）。
+const MAX_URL_LENGTH = 2048;
+const MAX_NOTE_LENGTH = 1000;
+
+type UserMetaRow = {
+  role: string | null;
+};
+
+// user_regulation_sheets の DB 行（snake_case）。
+type UserRegulationSheetRow = {
+  id: number;
+  user_id: string;
+  regulation_id: number;
+  yutosheet_url: string;
+  note: string;
+  updated_at: string | null;
+};
+
+// PUT のリクエストボディ。user_id / updated_by はボディから一切受け取らない（S-1）。
+type PutBody = {
+  regulationId: number;
+  yutosheetUrl: string;
+  note: string;
+};
+
+// エラーレスポンスは { error, code } 固定。内部詳細・スタック・upstream 本文は含めない。
+function errorResponse(error: string, code: string, status: number): NextResponse {
+  return NextResponse.json({ error, code }, { status });
+}
+
+function unauthorized(): NextResponse {
+  return errorResponse("認証が必要です", "UNAUTHORIZED", 401);
+}
+
+function forbidden(): NextResponse {
+  return errorResponse("権限がありません", "FORBIDDEN", 403);
+}
+
+function badRequest(): NextResponse {
+  return errorResponse("不正なリクエストです", "BAD_REQUEST", 400);
+}
+
+function internalError(): NextResponse {
+  return errorResponse("サーバーエラーが発生しました", "INTERNAL_ERROR", 500);
+}
+
+// snake_case → camelCase 変換（既存データ取得関数のスタイルに準拠）。
+function toCamel(row: UserRegulationSheetRow): UserRegulationSheetType {
+  return {
+    id: Number(row.id),
+    userId: String(row.user_id),
+    regulationId: Number(row.regulation_id),
+    yutosheetUrl: String(row.yutosheet_url),
+    note: String(row.note),
+    updatedAt: row.updated_at !== null && row.updated_at !== undefined ? String(row.updated_at) : null,
+  };
+}
+
+// 多重防御の認可: セッション再検証 + フェイルクローズ allowlist。
+// 認可成功時は本人の user.id を返す。失敗時は対応するエラーレスポンスを返す。
+async function authorize(
+  request: NextRequest
+): Promise<{ userId: string } | { response: NextResponse }> {
+  // anon key + cookie バインドの session client で本人を取得する。
+  const response = NextResponse.next();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll: () => request.cookies.getAll(),
+        setAll: (cookiesToSet) => {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            response.cookies.set(name, value, options);
+          });
+        },
+      },
+    }
+  );
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // 未認証 → 401。
+  if (!user) {
+    return { response: unauthorized() };
+  }
+
+  // user_meta（本人 row）から role を取得し、allowlist 厳密一致のみ許可（フェイルクローズ）。
+  let role: string | null = null;
+  try {
+    const { data: userMeta } = await supabase
+      .from("user_meta")
+      .select("role")
+      .eq("id", user.id)
+      .single<UserMetaRow>();
+    role = userMeta?.role ?? null;
+  } catch {
+    role = null;
+  }
+
+  const allowed =
+    typeof role === "string" &&
+    (ALLOWED_ROLES as readonly string[]).includes(role);
+
+  if (!allowed) {
+    return { response: forbidden() };
+  }
+
+  return { userId: user.id };
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await authorize(request);
+    if ("response" in auth) {
+      return auth.response;
+    }
+    const userId = auth.userId;
+
+    // 本人スコープを必ず付与する（RLS に加えて明示的に user_id 条件を付ける多重防御）。
+    const { data, error } = await supabaseAdmin
+      .from("user_regulation_sheets")
+      .select("id, user_id, regulation_id, yutosheet_url, note, updated_at")
+      .eq("user_id", userId)
+      .order("regulation_id", { ascending: true });
+
+    if (error) {
+      return internalError();
+    }
+
+    const rows = (data ?? []) as UserRegulationSheetRow[];
+    // getUserRegulationSheet が期待する camelCase 配列で返却する。
+    return NextResponse.json(rows.map(toCamel));
+  } catch {
+    return internalError();
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const auth = await authorize(request);
+    if ("response" in auth) {
+      return auth.response;
+    }
+    const userId = auth.userId;
+
+    // CSRF 対策（S-3 / M-4）: Origin ヘッダを自オリジンと照合する。
+    // 不一致・欠落は同一オリジンと判断できないため拒否する。
+    const origin = request.headers.get("origin");
+    if (origin !== request.nextUrl.origin) {
+      return forbidden();
+    }
+
+    const body = (await request.json()) as Partial<PutBody>;
+
+    // regulationId は整数のみ許可（小数 / NaN / 非数は 400）。
+    const regulationId = body.regulationId;
+    if (typeof regulationId !== "number" || !Number.isInteger(regulationId)) {
+      return badRequest();
+    }
+
+    // yutosheetUrl: 空文字は許可（未設定クリア相当）。非空は長さ + S-1 検証。
+    const yutosheetUrl = typeof body.yutosheetUrl === "string" ? body.yutosheetUrl : "";
+    if (yutosheetUrl.length > MAX_URL_LENGTH) {
+      return badRequest();
+    }
+    if (yutosheetUrl !== "" && validateYutosheetUrl(yutosheetUrl) === null) {
+      return badRequest();
+    }
+
+    // note: 最大 1000 字。
+    const note = typeof body.note === "string" ? body.note : "";
+    if (note.length > MAX_NOTE_LENGTH) {
+      return badRequest();
+    }
+
+    // regulationId が対象集合（level_cap_schedule 登録ありの全レギュレーション = フォームで
+    // 一覧表示する対象）に属するか確認する。最新 1 件ではなく対象集合全体で検証する。
+    const scheduledRegulations = await getScheduledRegulations();
+    const isAllowedRegulation = scheduledRegulations.some(
+      (regulation) => regulation.id === regulationId
+    );
+    if (!isAllowedRegulation) {
+      return badRequest();
+    }
+
+    // upsert。user_id / updated_by はセッション由来（userId）で固定。ボディ指定は無視（S-1）。
+    // ON CONFLICT (user_id, regulation_id) で本人 × レギュレーションを 1 レコードに保つ。
+    const { error } = await supabaseAdmin
+      .from("user_regulation_sheets")
+      .upsert(
+        {
+          user_id: userId,
+          regulation_id: regulationId,
+          yutosheet_url: yutosheetUrl,
+          note,
+          updated_by: userId,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: "user_id,regulation_id" }
+      );
+
+    if (error) {
+      return internalError();
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch {
+    return internalError();
+  }
+}

--- a/application/frontend/client/app/api/yutosheet/route.ts
+++ b/application/frontend/client/app/api/yutosheet/route.ts
@@ -1,0 +1,234 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import { validateYutosheetUrl } from "@/const/function/validateYutosheetUrl";
+import type { YutosheetJsonType } from "@/const/type/mypage/YutosheetJsonType";
+import type { UserRoleType } from "@/const/type/auth/UserRoleType";
+
+// マイページ機能の認可は user_meta.role の allowlist（フェイルクローズ）で行う。
+const ALLOWED_ROLES: readonly UserRoleType[] = ["general", "admin"];
+
+// プロキシ fetch のリソース制限（設計 S-2）。
+const FETCH_TIMEOUT_MS = 8000;
+const MAX_RESPONSE_BYTES = 2 * 1024 * 1024; // 2MB
+
+// 許可する Content-Type（JSON のみ）。
+const ALLOWED_CONTENT_TYPES: readonly string[] = [
+  "application/json",
+];
+
+type UserMetaRow = {
+  role: string | null;
+};
+
+// 外部 JSON はスキーマ保証がないため any/unknown を使わず
+// Record<string, string | number | boolean | null> として受ける。
+type RawJson = Record<string, string | number | boolean | null>;
+
+// エラーレスポンスは { error, code } 固定。upstream 本文・内部詳細は含めない。
+function errorResponse(error: string, code: string, status: number): NextResponse {
+  return NextResponse.json({ error, code }, { status });
+}
+
+function unauthorized(): NextResponse {
+  return errorResponse("認証が必要です", "UNAUTHORIZED", 401);
+}
+
+function forbidden(): NextResponse {
+  return errorResponse("権限がありません", "FORBIDDEN", 403);
+}
+
+function badRequest(): NextResponse {
+  return errorResponse("不正なリクエストです", "BAD_REQUEST", 400);
+}
+
+function upstreamError(): NextResponse {
+  return errorResponse("外部データの取得に失敗しました", "UPSTREAM_ERROR", 502);
+}
+
+function internalError(): NextResponse {
+  return errorResponse("サーバーエラーが発生しました", "INTERNAL_ERROR", 500);
+}
+
+// 数値化ヘルパ。number はそのまま、string はカンマ・空白除去後 Number()（NaN は 0）、その他 0。
+function toNumber(value: string | number | boolean | null | undefined): number {
+  if (typeof value === "number") {
+    return Number.isNaN(value) ? 0 : value;
+  }
+  if (typeof value === "string") {
+    const n = Number(value.replace(/[,\s]/g, ""));
+    return Number.isNaN(n) ? 0 : n;
+  }
+  return 0;
+}
+
+// 多重防御の認可: セッション再検証 + フェイルクローズ allowlist。
+async function authorize(request: NextRequest): Promise<boolean> {
+  const response = NextResponse.next();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll: () => request.cookies.getAll(),
+        setAll: (cookiesToSet) => {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            response.cookies.set(name, value, options);
+          });
+        },
+      },
+    }
+  );
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return false;
+  }
+
+  let role: string | null = null;
+  try {
+    const { data: userMeta } = await supabase
+      .from("user_meta")
+      .select("role")
+      .eq("id", user.id)
+      .single<UserMetaRow>();
+    role = userMeta?.role ?? null;
+  } catch {
+    role = null;
+  }
+
+  return (
+    typeof role === "string" &&
+    (ALLOWED_ROLES as readonly string[]).includes(role)
+  );
+}
+
+// ストリームを読みながら累積バイト数が上限を超えたら中断する（S-2 リソース制限）。
+// 上限超過時は null を返す（呼び出し側で 502）。
+async function readBounded(res: Response): Promise<string | null> {
+  const body = res.body;
+  if (body === null) {
+    return null;
+  }
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let received = 0;
+  let text = "";
+  let done = false;
+  while (!done) {
+    const chunk = await reader.read();
+    if (chunk.done) {
+      done = true;
+      break;
+    }
+    received += chunk.value.byteLength;
+    if (received > MAX_RESPONSE_BYTES) {
+      await reader.cancel();
+      return null;
+    }
+    text += decoder.decode(chunk.value, { stream: true });
+  }
+  text += decoder.decode();
+  return text;
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    // 多重防御の認可（middleware に加えて route でも再検証）。
+    const allowed = await authorize(request);
+    if (!allowed) {
+      // 未認証・権限外を区別せず最小情報で拒否する。
+      // ここでは getUser 失敗・role 不許可いずれも 403 に集約せず、
+      // 認証段階の有無で 401/403 を分けたいが、authorize は boolean のため
+      // 多重防御として 401 を返す（middleware が一次防御で 401/403 を出し分け済み）。
+      return unauthorized();
+    }
+
+    // S-1: ユーザー入力 URL を検証。null なら 400。
+    const urlParam = request.nextUrl.searchParams.get("url");
+    if (urlParam === null || urlParam === "") {
+      return badRequest();
+    }
+    const validated = validateYutosheetUrl(urlParam);
+    if (validated === null) {
+      return badRequest();
+    }
+
+    // 検証を通った URL に対してのみ、サーバー側で mode=json を付与する。
+    // URLSearchParams で安全に付与（ユーザー入力値は使わない）。
+    const target = new URL(validated.toString());
+    target.searchParams.set("mode", "json");
+
+    // S-2: プロキシ fetch の安全化。
+    // redirect:manual でリダイレクト追跡を禁止（内部 IP 到達・DNS リバインディング対策）。
+    // ホストは S-1 で yutorize.work 完全一致に限定済み。DNS 解決結果が内部 IP を指す
+    // リバインディングに対しては redirect:manual + ホスト固定で一次防御とする多重防御方針。
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    let res: Response;
+    try {
+      res = await fetch(target.toString(), {
+        method: "GET",
+        redirect: "manual",
+        signal: controller.signal,
+      });
+    } catch {
+      // タイムアウト（abort）・ネットワークエラーは upstream エラー扱い。
+      return upstreamError();
+    } finally {
+      clearTimeout(timer);
+    }
+
+    // 30x（リダイレクト）は追跡せず 502。
+    if (res.status >= 300 && res.status < 400) {
+      return upstreamError();
+    }
+    if (!res.ok) {
+      return upstreamError();
+    }
+
+    // Content-Type は JSON のみ許可。
+    const contentType = (res.headers.get("content-type") ?? "").toLowerCase();
+    const contentTypeAllowed = ALLOWED_CONTENT_TYPES.some((allowedType) =>
+      contentType.startsWith(allowedType)
+    );
+    if (!contentTypeAllowed) {
+      return upstreamError();
+    }
+
+    // 本文を最大 2MB まで読む（超過で中断 → 502）。
+    const text = await readBounded(res);
+    if (text === null) {
+      return upstreamError();
+    }
+
+    // plain JSON をパース（any/unknown 不使用）。
+    let raw: RawJson;
+    try {
+      const parsed = JSON.parse(text) as RawJson;
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        return upstreamError();
+      }
+      raw = parsed;
+    } catch {
+      return upstreamError();
+    }
+
+    // S-3: ホワイトリスト 5 フィールドのみ抽出し数値化して返却する。
+    // 生 JSONP 文字列・JSON 全体は返さない。
+    const result: YutosheetJsonType = {
+      characterName: typeof raw.characterName === "string" ? raw.characterName : "",
+      expTotal: toNumber(raw.expTotal),
+      historyGrowTotal: toNumber(raw.historyGrowTotal),
+      historyMoneyTotal: toNumber(raw.historyMoneyTotal),
+      historyHonorTotal: toNumber(raw.historyHonorTotal),
+    };
+
+    return NextResponse.json(result);
+  } catch {
+    return internalError();
+  }
+}

--- a/application/frontend/client/app/login/page.tsx
+++ b/application/frontend/client/app/login/page.tsx
@@ -1,0 +1,11 @@
+import LoginTemplate from "@/component/templates/LoginTemplate";
+import { COMMON } from "@/const/common/COMMON";
+import { LOGIN } from "@/const/pages/LOGIN";
+
+export const metadata = {
+  title: COMMON.SITE_NAME + "|" + LOGIN.TEXT.TITLE,
+};
+
+export default function LoginPage() {
+  return <LoginTemplate />;
+}

--- a/application/frontend/client/app/mypage/page.tsx
+++ b/application/frontend/client/app/mypage/page.tsx
@@ -1,0 +1,11 @@
+import MyPageTemplate from "@/component/templates/MyPageTemplate";
+import { COMMON } from "@/const/common/COMMON";
+import { MYPAGE } from "@/const/pages/MYPAGE";
+
+export const metadata = {
+  title: COMMON.SITE_NAME + "|" + MYPAGE.TEXT.TITLE,
+};
+
+export default function MyPage() {
+  return <MyPageTemplate />;
+}

--- a/application/frontend/client/component/atoms/AppButton.tsx
+++ b/application/frontend/client/component/atoms/AppButton.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { Button as ChakraButton } from "@chakra-ui/react";
+import type { ReactNode } from "react";
+
+type Props = {
+  children: ReactNode;
+  onClick?: () => void;
+  variant?: "primary" | "secondary" | "cancel";
+  size?: "sm" | "md" | "lg";
+  type?: "button" | "submit";
+  loading?: boolean;
+  disabled?: boolean;
+  fullWidth?: boolean;
+};
+
+export default function AppButton({
+  children,
+  onClick,
+  variant = "primary",
+  size = "md",
+  type = "button",
+  loading,
+  disabled,
+  fullWidth,
+}: Props) {
+  const colorPalette = variant === "cancel" ? "gray" : "blue";
+  const chakraVariant = "solid";
+
+  return (
+    <ChakraButton
+      type={type}
+      onClick={onClick}
+      size={size}
+      loading={loading}
+      disabled={disabled}
+      colorPalette={colorPalette}
+      variant={chakraVariant}
+      borderRadius="lg"
+      fontWeight="bold"
+      width={fullWidth ? "full" : undefined}
+    >
+      {children}
+    </ChakraButton>
+  );
+}

--- a/application/frontend/client/component/molecules/Header.tsx
+++ b/application/frontend/client/component/molecules/Header.tsx
@@ -3,16 +3,21 @@ import { useEffect, useState } from "react";
 import { Box } from "@chakra-ui/react";
 import { RxHamburgerMenu, RxCross1, RxChevronDown, RxChevronUp } from "react-icons/rx";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { STYLE_COLOR } from "@/const/style/STYLE_COLOR";
 import { STYLE } from "@/const/common/STYLE";
 import { COMMON } from "@/const/common/COMMON";
+import { PATH } from "@/const/common/PATH";
 import { NAV_ITEMS } from "@/const/common/NAV_ITEMS";
 import { getRegulationItems } from "@/const/function/getRegulationItems";
+import { supabase } from "@/lib/supabase";
 
 export default function Header() {
+  const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
   const [period, setPeriod] = useState("");
   const [openAccordion, setOpenAccordion] = useState<string | null>(null);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
 
   useEffect(() => {
     const fetchPeriod = async () => {
@@ -23,6 +28,28 @@ export default function Header() {
     };
     fetchPeriod();
   }, []);
+
+  useEffect(() => {
+    const initSession = async () => {
+      const { data } = await supabase.auth.getUser();
+      setIsLoggedIn(data.user !== null);
+    };
+    initSession();
+
+    const { data: subscription } = supabase.auth.onAuthStateChange((_event, session) => {
+      setIsLoggedIn(session !== null);
+    });
+
+    return () => {
+      subscription.subscription.unsubscribe();
+    };
+  }, []);
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+    router.push(PATH.URL.LOGIN);
+    setIsOpen(false);
+  };
 
   const navItems = NAV_ITEMS(period);
 
@@ -174,6 +201,41 @@ export default function Header() {
               )}
             </Box>
           ))}
+          {isLoggedIn === true && (
+            <>
+              <Box borderBottom={`1px solid ${STYLE_COLOR.LIGHT}`}>
+                <Link
+                  href={PATH.URL.MYPAGE}
+                  onClick={() => setIsOpen(false)}
+                  style={{ display: "block" }}
+                >
+                  <Box
+                    py={3}
+                    fontSize={"15px"}
+                    color={STYLE_COLOR.BLACK}
+                    _hover={{ color: STYLE_COLOR.PRIMARY }}
+                  >
+                    {COMMON.MYPAGE_LABEL}
+                  </Box>
+                </Link>
+              </Box>
+              <Box borderBottom={`1px solid ${STYLE_COLOR.LIGHT}`}>
+                <Box
+                  as="button"
+                  width="100%"
+                  textAlign="left"
+                  py={3}
+                  fontSize={"15px"}
+                  color={STYLE_COLOR.BLACK}
+                  cursor="pointer"
+                  _hover={{ color: STYLE_COLOR.PRIMARY }}
+                  onClick={handleLogout}
+                >
+                  {COMMON.LOGOUT_LABEL}
+                </Box>
+              </Box>
+            </>
+          )}
         </Box>
       </Box>
     </>

--- a/application/frontend/client/component/molecules/field/TextInputField.tsx
+++ b/application/frontend/client/component/molecules/field/TextInputField.tsx
@@ -1,0 +1,40 @@
+"use client";
+import { Field, Input } from "@chakra-ui/react";
+import { STYLE_COLOR } from "@/const/style/STYLE_COLOR";
+
+type Props = {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  type?: "text" | "password";
+  required?: boolean;
+  placeholder?: string;
+  helperText?: string;
+};
+
+export default function TextInputField({ label, value, onChange, type = "text", required, placeholder, helperText }: Props) {
+  return (
+    <Field.Root required={required}>
+      <Field.Label color={STYLE_COLOR.PRIMARY} fontWeight="bold" mb={1}>
+        {label}
+        {required && <Field.RequiredIndicator />}
+      </Field.Label>
+      <Input
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        size="lg"
+        bg={STYLE_COLOR.WHITE}
+        borderWidth="1px"
+        borderColor={STYLE_COLOR.BORDER}
+        borderRadius="lg"
+        boxShadow="sm"
+        color={STYLE_COLOR.BLACK}
+        _hover={{ borderColor: STYLE_COLOR.SECONDARY }}
+        _focus={{ borderColor: STYLE_COLOR.SECONDARY, boxShadow: `0 0 0 1px ${STYLE_COLOR.SECONDARY}`, outline: "none" }}
+      />
+      {helperText && <Field.HelperText fontSize="xs">{helperText}</Field.HelperText>}
+    </Field.Root>
+  );
+}

--- a/application/frontend/client/component/molecules/field/TextareaField.tsx
+++ b/application/frontend/client/component/molecules/field/TextareaField.tsx
@@ -1,0 +1,41 @@
+"use client";
+import { Field, Textarea } from "@chakra-ui/react";
+import { STYLE_COLOR } from "@/const/style/STYLE_COLOR";
+
+type Props = {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  required?: boolean;
+  placeholder?: string;
+  helperText?: string;
+  rows?: number;
+};
+
+export default function TextareaField({ label, value, onChange, required, placeholder, helperText, rows }: Props) {
+  return (
+    <Field.Root required={required}>
+      <Field.Label color={STYLE_COLOR.PRIMARY} fontWeight="bold" mb={1}>
+        {label}
+        {required && <Field.RequiredIndicator />}
+      </Field.Label>
+      <Textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        rows={rows ?? 8}
+        bg={STYLE_COLOR.WHITE}
+        borderWidth="1px"
+        borderColor={STYLE_COLOR.BORDER}
+        borderRadius="lg"
+        boxShadow="sm"
+        color={STYLE_COLOR.BLACK}
+        px={4}
+        py={3}
+        _hover={{ borderColor: STYLE_COLOR.SECONDARY }}
+        _focus={{ borderColor: STYLE_COLOR.SECONDARY, boxShadow: `0 0 0 1px ${STYLE_COLOR.SECONDARY}`, outline: "none" }}
+      />
+      {helperText && <Field.HelperText fontSize="xs">{helperText}</Field.HelperText>}
+    </Field.Root>
+  );
+}

--- a/application/frontend/client/component/organisms/login/LoginForm.tsx
+++ b/application/frontend/client/component/organisms/login/LoginForm.tsx
@@ -1,0 +1,89 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { VStack, Alert } from "@chakra-ui/react";
+import AppButton from "@/component/atoms/AppButton";
+import TextInputField from "@/component/molecules/field/TextInputField";
+import { LOGIN } from "@/const/pages/LOGIN";
+import { useErrorHandler } from "@/hooks/useErrorHandler";
+import type { UserRoleType } from "@/const/type/auth/UserRoleType";
+
+export default function LoginForm() {
+  const router = useRouter();
+  const { errorAlertDescription, handleError, resetError } = useErrorHandler();
+  const [userId, setUserId] = useState("");
+  const [password, setPassword] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const passwordMinLength = Number(LOGIN.VALUE.PASSWORD_MIN_LENGTH);
+  const isSubmitDisabled =
+    userId === "" || password === "" || password.length < passwordMinLength;
+
+  const showError = (message: string) => {
+    handleError({ body: { detail: message }, status: 0 });
+  };
+
+  const handleSubmit = async () => {
+    resetError();
+    setIsLoading(true);
+    try {
+      const res = await fetch("/api/auth", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "login", userId, password }),
+      });
+
+      if (!res.ok) {
+        showError(LOGIN.TEXT.ERROR_INVALID);
+        return;
+      }
+
+      const data = (await res.json()) as { role: UserRoleType | null };
+      // 成功 role が general/admin → /mypage（オープンリダイレクト予防のため内部固定パスのリテラルのみ）。
+      if (data.role === "general" || data.role === "admin") {
+        router.push("/mypage");
+        return;
+      }
+
+      // 成功 role が common → 留まって権限なしエラーを表示。
+      showError(LOGIN.TEXT.ERROR_NO_PERMISSION);
+    } catch {
+      showError(LOGIN.TEXT.ERROR_INVALID);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <VStack gap={4} w="full">
+      {errorAlertDescription !== "" && (
+        <Alert.Root status="error">
+          <Alert.Indicator />
+          <Alert.Description>{errorAlertDescription}</Alert.Description>
+        </Alert.Root>
+      )}
+      <TextInputField
+        label={LOGIN.TEXT.USER_ID_LABEL}
+        value={userId}
+        onChange={setUserId}
+        required
+      />
+      <TextInputField
+        label={LOGIN.TEXT.PASSWORD_LABEL}
+        value={password}
+        onChange={setPassword}
+        type="password"
+        required
+      />
+      <AppButton
+        variant="primary"
+        fullWidth
+        onClick={handleSubmit}
+        loading={isLoading}
+        disabled={isSubmitDisabled}
+      >
+        {LOGIN.TEXT.SUBMIT}
+      </AppButton>
+    </VStack>
+  );
+}

--- a/application/frontend/client/component/organisms/mypage/GrowthGuide.tsx
+++ b/application/frontend/client/component/organisms/mypage/GrowthGuide.tsx
@@ -1,0 +1,229 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Box, VStack, HStack, Flex, SimpleGrid, Text, Spinner, Alert } from "@chakra-ui/react";
+import {
+  LuSparkles,
+  LuTrendingUp,
+  LuCoins,
+  LuStar,
+  LuInfo,
+  LuTarget,
+  LuCircleCheck,
+} from "react-icons/lu";
+import { resolveCurrentLevelCap } from "@/const/function/resolveCurrentLevelCap";
+import { calcGrowthGuide } from "@/const/function/calcGrowthGuide";
+import { useErrorHandler } from "@/hooks/useErrorHandler";
+import { STYLE_COLOR } from "@/const/style/STYLE_COLOR";
+import { MYPAGE } from "@/const/pages/MYPAGE";
+import type { GrowthGuideItemType, GrowthGuideKind } from "@/const/type/mypage/GrowthGuideType";
+import type { YutosheetJsonType } from "@/const/type/mypage/YutosheetJsonType";
+import type { LatestScheduledRegulationType } from "@/const/type/mypage/LatestScheduledRegulationType";
+
+type Props = {
+  regulation: LatestScheduledRegulationType;
+  registeredUrl: string;
+};
+
+// 取得状態の判別用。loading 後にどの表示にするかを 1 つの state で表す。
+type GuideStatus = "noUrl" | "ready";
+
+export default function GrowthGuide({ regulation, registeredUrl }: Props) {
+  const { errorAlertDescription, handleError } = useErrorHandler();
+  const [loading, setLoading] = useState(true);
+  const [status, setStatus] = useState<GuideStatus>("noUrl");
+  const [items, setItems] = useState<GrowthGuideItemType[]>([]);
+  const [currentLevel, setCurrentLevel] = useState("");
+
+  useEffect(() => {
+    const fetchGuide = async () => {
+      try {
+        // 1. 本人のゆとシート URL（props）。未登録なら設定セクションへ誘導。
+        if (registeredUrl === "") {
+          setStatus("noUrl");
+          return;
+        }
+
+        // 2. ゆとシート JSON を /api/yutosheet 経由で取得。
+        const res = await fetch(
+          `/api/yutosheet?url=${encodeURIComponent(registeredUrl)}`,
+          { method: "GET", headers: { Accept: "application/json" } }
+        );
+        if (!res.ok) {
+          throw new Error(`Failed to fetch yutosheet: ${res.status}`);
+        }
+        const yutosheet = (await res.json()) as YutosheetJsonType;
+
+        // 3. 現在のレベルキャップを解決。null（未開始）なら GUIDE_NONE（items 空）。
+        const levelCap = await resolveCurrentLevelCap(
+          regulation.levelCapSchedule,
+          regulation.levelCapBelt
+        );
+        if (levelCap === null) {
+          setItems([]);
+          setStatus("ready");
+          return;
+        }
+        setCurrentLevel(levelCap.level);
+
+        // 4. 成長指示計算。
+        const guide = calcGrowthGuide({
+          expTotal: yutosheet.expTotal,
+          historyGrowTotal: yutosheet.historyGrowTotal,
+          historyMoneyTotal: yutosheet.historyMoneyTotal,
+          historyHonorTotal: yutosheet.historyHonorTotal,
+          minExp: levelCap.minExp,
+          minGrowth: levelCap.minGrowth,
+          minReward: levelCap.minReward,
+          minHonor: levelCap.minHonor,
+          expDiff: levelCap.expDiff,
+        });
+        setItems(guide);
+        setStatus("ready");
+      } catch (err) {
+        handleError({ body: { detail: String(err) }, status: 0 });
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchGuide();
+  }, [handleError, regulation, registeredUrl]);
+
+  // kind ごとのラベル・単位を組み立てる（文言は MYPAGE 定数から）。
+  const labelOf = (kind: GrowthGuideKind): string => {
+    if (kind === "exp") return MYPAGE.TEXT.GUIDE_EXP;
+    if (kind === "growth") return MYPAGE.TEXT.GUIDE_GROWTH;
+    if (kind === "reward") return MYPAGE.TEXT.GUIDE_REWARD;
+    return MYPAGE.TEXT.GUIDE_HONOR;
+  };
+
+  const unitOf = (kind: GrowthGuideKind): string => {
+    if (kind === "exp") return String(MYPAGE.VALUE.UNIT_EXP);
+    if (kind === "growth") return String(MYPAGE.VALUE.UNIT_GROWTH);
+    if (kind === "reward") return String(MYPAGE.VALUE.UNIT_REWARD);
+    return String(MYPAGE.VALUE.UNIT_HONOR);
+  };
+
+  const iconOf = (kind: GrowthGuideKind) => {
+    if (kind === "exp") return <LuSparkles size={16} />;
+    if (kind === "growth") return <LuTrendingUp size={16} />;
+    if (kind === "reward") return <LuCoins size={16} />;
+    return <LuStar size={16} />;
+  };
+
+  const GuideItem = ({ item }: { item: GrowthGuideItemType }) => (
+    <VStack
+      as="li"
+      align="stretch"
+      gap={1}
+      listStyleType="none"
+      bg={STYLE_COLOR.WHITE}
+      borderWidth="1px"
+      borderColor={STYLE_COLOR.BORDER}
+      borderRadius="xl"
+      px={4}
+      py={3}
+    >
+      <HStack gap={2} color={STYLE_COLOR.SECONDARY}>
+        <Box>{iconOf(item.kind)}</Box>
+        <Text fontSize="sm" fontWeight="bold">
+          {labelOf(item.kind)}
+        </Text>
+      </HStack>
+      <HStack align="baseline" gap={1}>
+        <Text fontSize="2xl" fontWeight="bold" color={STYLE_COLOR.PRIMARY}>
+          +{item.value.toLocaleString()}
+        </Text>
+        <Text fontSize="sm" color={STYLE_COLOR.BLACK}>
+          {unitOf(item.kind)}
+        </Text>
+      </HStack>
+    </VStack>
+  );
+
+  return (
+    <Box>
+      {loading && (
+        <Flex justify="center" py={6}>
+          <Spinner color={STYLE_COLOR.PRIMARY} />
+        </Flex>
+      )}
+      {errorAlertDescription !== "" && (
+        <Alert.Root status="error" mb={4}>
+          <Alert.Indicator />
+          <Alert.Description>{errorAlertDescription}</Alert.Description>
+        </Alert.Root>
+      )}
+      {!loading && status === "noUrl" && (
+        <HStack align="flex-start" gap={3} bg={STYLE_COLOR.LIGHT} borderRadius="xl" px={4} py={4}>
+          <Box color={STYLE_COLOR.PRIMARY}>
+            <LuInfo size={20} />
+          </Box>
+          <Text color={STYLE_COLOR.BLACK} fontSize="sm">
+            {MYPAGE.TEXT.NO_URL}
+          </Text>
+        </HStack>
+      )}
+      {!loading && status === "ready" && (
+        <VStack align="stretch" gap={4}>
+          <Flex align="center" justify="space-between" gap={3} wrap="wrap">
+            <HStack gap={2}>
+              <Box color={STYLE_COLOR.PRIMARY}>
+                <LuTarget size={22} />
+              </Box>
+              <Text fontSize="18px" fontWeight="bold" color={STYLE_COLOR.PRIMARY}>
+                {MYPAGE.TEXT.GUIDE_LABEL}
+              </Text>
+            </HStack>
+            {currentLevel !== "" && (
+              <HStack
+                gap={2}
+                bg={STYLE_COLOR.PRIMARY}
+                color={STYLE_COLOR.WHITE}
+                px={3}
+                py={1}
+                borderRadius="full"
+              >
+                <Text as="span" fontSize="xs">
+                  {MYPAGE.TEXT.CURRENT_LEVEL}
+                </Text>
+                <Text as="span" fontSize="md" fontWeight="bold">
+                  {currentLevel}
+                </Text>
+              </HStack>
+            )}
+          </Flex>
+          {items.length === 0 && (
+            <HStack
+              gap={3}
+              bg={STYLE_COLOR.WHITE}
+              borderWidth="1px"
+              borderColor={STYLE_COLOR.BORDER}
+              borderRadius="xl"
+              px={4}
+              py={4}
+            >
+              <Box color={STYLE_COLOR.SUCCESS}>
+                <LuCircleCheck size={22} />
+              </Box>
+              <Text fontSize="16px" fontWeight="medium" color={STYLE_COLOR.BLACK}>
+                {MYPAGE.TEXT.GUIDE_NONE}
+              </Text>
+            </HStack>
+          )}
+          {items.length > 0 && (
+            <VStack align="stretch" gap={3}>
+              <Text fontSize="sm" color={STYLE_COLOR.BLACK}>
+                {MYPAGE.TEXT.GUIDE_DESC}
+              </Text>
+              <SimpleGrid as="ul" columns={{ base: 1, sm: 2 }} gap={3}>
+                {items.map((item) => (
+                  <GuideItem key={item.kind} item={item} />
+                ))}
+              </SimpleGrid>
+            </VStack>
+          )}
+        </VStack>
+      )}
+    </Box>
+  );
+}

--- a/application/frontend/client/component/organisms/mypage/RegulationSheetForm.tsx
+++ b/application/frontend/client/component/organisms/mypage/RegulationSheetForm.tsx
@@ -1,0 +1,351 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Box, VStack, Stack, HStack, Flex, Text, Alert, Spinner, Link } from "@chakra-ui/react";
+import { LuStar, LuUser, LuStickyNote, LuPencil, LuExternalLink } from "react-icons/lu";
+import AppButton from "@/component/atoms/AppButton";
+import GrowthGuide from "@/component/organisms/mypage/GrowthGuide";
+import TextInputField from "@/component/molecules/field/TextInputField";
+import TextareaField from "@/component/molecules/field/TextareaField";
+import { getScheduledRegulations } from "@/const/function/getScheduledRegulations";
+import { getUserRegulationSheet } from "@/const/function/getUserRegulationSheet";
+import { getLatestScheduledRegulation } from "@/const/function/getLatestScheduledRegulation";
+import { validateYutosheetUrl } from "@/const/function/validateYutosheetUrl";
+import { useErrorHandler } from "@/hooks/useErrorHandler";
+import { STYLE_COLOR } from "@/const/style/STYLE_COLOR";
+import { MYPAGE } from "@/const/pages/MYPAGE";
+import type { LatestScheduledRegulationType } from "@/const/type/mypage/LatestScheduledRegulationType";
+import type { UserRegulationSheetType } from "@/const/type/mypage/UserRegulationSheetType";
+import type { YutosheetJsonType } from "@/const/type/mypage/YutosheetJsonType";
+
+export default function RegulationSheetForm() {
+  const { errorAlertDescription, handleError, resetError } = useErrorHandler();
+  const [regulations, setRegulations] = useState<LatestScheduledRegulationType[]>([]);
+  const [sheets, setSheets] = useState<UserRegulationSheetType[]>([]);
+  const [latest, setLatest] = useState<LatestScheduledRegulationType | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [regs, userSheets, latestReg] = await Promise.all([
+          getScheduledRegulations(),
+          getUserRegulationSheet(),
+          getLatestScheduledRegulation(),
+        ]);
+        setRegulations(regs);
+        setSheets(userSheets);
+        setLatest(latestReg);
+      } catch (err) {
+        handleError({ body: { detail: String(err) }, status: 0 });
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [handleError]);
+
+  const findSheet = (regulationId: number): UserRegulationSheetType | undefined =>
+    sheets.find((sheet) => sheet.regulationId === regulationId);
+
+  // 最新レギュレーションのブロックを先頭に並べ替える（最新が null なら元順）。
+  const orderRegulations = (): LatestScheduledRegulationType[] => {
+    if (latest === null) {
+      return regulations;
+    }
+    const latestId = latest.id;
+    const head = regulations.filter((reg) => reg.id === latestId);
+    const rest = regulations.filter((reg) => reg.id !== latestId);
+    return [...head, ...rest];
+  };
+
+  // 1 レギュレーション分のブロック。親内 const として定義（規約 7・8）。
+  const RegulationBlock = ({ regulation }: { regulation: LatestScheduledRegulationType }) => {
+    const saved = findSheet(regulation.id);
+    const isLatest = latest !== null && latest.id === regulation.id;
+    const [url, setUrl] = useState(saved?.yutosheetUrl ?? "");
+    const [note, setNote] = useState(saved?.note ?? "");
+    const [isSaving, setIsSaving] = useState(false);
+    const [isSaved, setIsSaved] = useState(false);
+    const [invalidUrl, setInvalidUrl] = useState(false);
+    const [isEditing, setIsEditing] = useState(false);
+    const [characterName, setCharacterName] = useState("");
+
+    // 表示モードのリンクテキスト用にキャラクター名を取得する。
+    const loadCharacterName = async () => {
+      if (url === "" || validateYutosheetUrl(url) === null) {
+        setCharacterName("");
+        return;
+      }
+      try {
+        const res = await fetch(`/api/yutosheet?url=${encodeURIComponent(url)}`, {
+          method: "GET",
+          headers: { Accept: "application/json" },
+        });
+        if (!res.ok) {
+          throw new Error(`Failed to fetch yutosheet: ${res.status}`);
+        }
+        const yutosheet = (await res.json()) as YutosheetJsonType;
+        setCharacterName(yutosheet.characterName);
+      } catch (err) {
+        handleError({ body: { detail: String(err) }, status: 0 });
+      }
+    };
+
+    useEffect(() => {
+      loadCharacterName();
+    }, [url]);
+
+    const handleEdit = () => {
+      setIsSaved(false);
+      setInvalidUrl(false);
+      setIsEditing(true);
+    };
+
+    const handleCancel = () => {
+      setUrl(saved?.yutosheetUrl ?? "");
+      setNote(saved?.note ?? "");
+      setInvalidUrl(false);
+      setIsSaved(false);
+      setIsEditing(false);
+    };
+
+    const handleSave = async () => {
+      resetError();
+      setIsSaved(false);
+      setInvalidUrl(false);
+
+      // クライアント側でも軽く検証（空文字は許可。サーバーが最終防御）。
+      if (url !== "" && validateYutosheetUrl(url) === null) {
+        setInvalidUrl(true);
+        return;
+      }
+
+      setIsSaving(true);
+      try {
+        const res = await fetch("/api/mypage", {
+          method: "PUT",
+          credentials: "same-origin",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            regulationId: regulation.id,
+            yutosheetUrl: url,
+            note,
+          }),
+        });
+        if (!res.ok) {
+          throw new Error(`Failed to save: ${res.status}`);
+        }
+        setIsSaved(true);
+        setIsEditing(false);
+      } catch (err) {
+        handleError({ body: { detail: String(err) }, status: 0 });
+      } finally {
+        setIsSaving(false);
+      }
+    };
+
+    return (
+      <Box
+        bg={STYLE_COLOR.WHITE}
+        borderWidth="1px"
+        borderColor={isLatest ? STYLE_COLOR.SECONDARY : STYLE_COLOR.BORDER}
+        borderRadius="2xl"
+        boxShadow={isLatest ? "lg" : "sm"}
+        overflow="hidden"
+      >
+        <Flex
+          align="center"
+          justify="space-between"
+          px={5}
+          py={4}
+          bg={isLatest ? STYLE_COLOR.PRIMARY : STYLE_COLOR.COMMON}
+        >
+          <Text
+            as="h3"
+            fontSize="20px"
+            fontWeight="bold"
+            fontFamily="var(--font-edu-nsw-act-cursive), var(--font-zen-maru-gothic)"
+            color={isLatest ? STYLE_COLOR.WHITE : STYLE_COLOR.PRIMARY}
+          >
+            {regulation.name}
+          </Text>
+          {isLatest && (
+            <HStack
+              bg={STYLE_COLOR.ACCENT}
+              color={STYLE_COLOR.WHITE}
+              px={3}
+              py={1}
+              borderRadius="full"
+              fontSize="xs"
+              fontWeight="bold"
+              gap={1}
+            >
+              <LuStar size={12} />
+              <Text as="span">{MYPAGE.TEXT.LATEST_BADGE}</Text>
+            </HStack>
+          )}
+        </Flex>
+        <Box px={5} py={5}>
+          {!isEditing && (
+            <VStack align="stretch" gap={4}>
+              <HStack align="flex-start" gap={3}>
+                <Flex
+                  align="center"
+                  justify="center"
+                  boxSize="40px"
+                  borderRadius="full"
+                  bg={STYLE_COLOR.LIGHT}
+                  color={STYLE_COLOR.PRIMARY}
+                  flexShrink={0}
+                >
+                  <LuUser size={20} />
+                </Flex>
+                <Box flex="1" minW={0}>
+                  <Text fontSize="xs" fontWeight="bold" color={STYLE_COLOR.SECONDARY} mb={1}>
+                    {MYPAGE.TEXT.CHARACTER_LABEL}
+                  </Text>
+                  {url === "" && (
+                    <Text color={STYLE_COLOR.BLACK} fontWeight="medium">
+                      {MYPAGE.TEXT.UNREGISTERED}
+                    </Text>
+                  )}
+                  {url !== "" && validateYutosheetUrl(url) !== null && (
+                    <Link
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      color={STYLE_COLOR.PRIMARY}
+                      fontWeight="bold"
+                      wordBreak="break-all"
+                      display="inline-flex"
+                      alignItems="center"
+                      gap={1}
+                      _hover={{ color: STYLE_COLOR.ACCENT }}
+                    >
+                      {characterName !== "" ? characterName : url}
+                      <LuExternalLink size={14} />
+                    </Link>
+                  )}
+                  {url !== "" && validateYutosheetUrl(url) === null && (
+                    <Text color={STYLE_COLOR.BLACK} wordBreak="break-all">
+                      {url}
+                    </Text>
+                  )}
+                </Box>
+              </HStack>
+              {note !== "" && (
+                <HStack align="flex-start" gap={3}>
+                  <Flex
+                    align="center"
+                    justify="center"
+                    boxSize="40px"
+                    borderRadius="full"
+                    bg={STYLE_COLOR.LIGHT}
+                    color={STYLE_COLOR.PRIMARY}
+                    flexShrink={0}
+                  >
+                    <LuStickyNote size={18} />
+                  </Flex>
+                  <Box flex="1" minW={0}>
+                    <Text fontSize="xs" fontWeight="bold" color={STYLE_COLOR.SECONDARY} mb={1}>
+                      {MYPAGE.TEXT.CHARACTOR_ROLE_LABEL}
+                    </Text>
+                    <Text color={STYLE_COLOR.BLACK} whiteSpace="pre-wrap">
+                      {note}
+                    </Text>
+                  </Box>
+                </HStack>
+              )}
+              <Box>
+                <AppButton variant="secondary" size="sm" onClick={handleEdit}>
+                  <HStack as="span" gap={1.5}>
+                    <LuPencil size={14} />
+                    <Text as="span">{MYPAGE.TEXT.EDIT}</Text>
+                  </HStack>
+                </AppButton>
+              </Box>
+            </VStack>
+          )}
+          {isEditing && (
+            <Stack gap={3}>
+              <TextInputField
+                label={MYPAGE.TEXT.URL_LABEL}
+                value={url}
+                onChange={setUrl}
+                placeholder={String(MYPAGE.VALUE.URL_PLACEHOLDER)}
+                helperText={MYPAGE.TEXT.URL_HELP}
+              />
+              <TextareaField
+                label={MYPAGE.TEXT.CHARACTOR_ROLE_LABEL}
+                value={note}
+                onChange={setNote}
+                placeholder={String(MYPAGE.VALUE.NOTE_PLACEHOLDER)}
+                helperText={MYPAGE.TEXT.NOTE_HELP}
+                rows={3}
+              />
+              {invalidUrl && (
+                <Text color={STYLE_COLOR.ERROR} fontSize="sm">
+                  {MYPAGE.TEXT.INVALID_URL}
+                </Text>
+              )}
+              {isSaved && (
+                <Text color={STYLE_COLOR.PRIMARY} fontSize="sm">
+                  {MYPAGE.TEXT.SAVED}
+                </Text>
+              )}
+              <HStack gap={3}>
+                <AppButton variant="primary" size="sm" onClick={handleSave} loading={isSaving}>
+                  {MYPAGE.TEXT.SAVE}
+                </AppButton>
+                <AppButton variant="cancel" size="sm" onClick={handleCancel}>
+                  {MYPAGE.TEXT.CANCEL}
+                </AppButton>
+              </HStack>
+            </Stack>
+          )}
+        </Box>
+        {isLatest && !isEditing && (
+          <Box bg={STYLE_COLOR.COMMON} borderTop={`1px solid ${STYLE_COLOR.BORDER}`} px={5} py={5}>
+            <GrowthGuide regulation={regulation} registeredUrl={url} />
+          </Box>
+        )}
+      </Box>
+    );
+  };
+
+  return (
+    <Box>
+      {loading && (
+        <Flex justify="center" py={10}>
+          <Spinner color={STYLE_COLOR.PRIMARY} />
+        </Flex>
+      )}
+      {errorAlertDescription !== "" && (
+        <Alert.Root status="error" mb={4}>
+          <Alert.Indicator />
+          <Alert.Description>{errorAlertDescription}</Alert.Description>
+        </Alert.Root>
+      )}
+      {!loading && regulations.length === 0 && (
+        <Box
+          bg={STYLE_COLOR.WHITE}
+          borderWidth="1px"
+          borderColor={STYLE_COLOR.BORDER}
+          borderRadius="2xl"
+          px={6}
+          py={10}
+          textAlign="center"
+        >
+          <Text color={STYLE_COLOR.BLACK}>{MYPAGE.TEXT.NO_LATEST}</Text>
+        </Box>
+      )}
+      {!loading && regulations.length > 0 && (
+        <VStack gap={6} align="stretch">
+          {orderRegulations().map((regulation) => (
+            <RegulationBlock key={regulation.id} regulation={regulation} />
+          ))}
+        </VStack>
+      )}
+    </Box>
+  );
+}

--- a/application/frontend/client/component/templates/LoginTemplate.tsx
+++ b/application/frontend/client/component/templates/LoginTemplate.tsx
@@ -1,0 +1,16 @@
+import { Box, Center, Heading } from "@chakra-ui/react";
+import LoginForm from "@/component/organisms/login/LoginForm";
+import { LOGIN } from "@/const/pages/LOGIN";
+
+export default function LoginTemplate() {
+  return (
+    <Center minH="100vh" bg="gray.50">
+      <Box bg="white" p={8} borderRadius="lg" shadow="md" w="full" maxW="400px">
+        <Heading size="lg" mb={6} textAlign="center">
+          {LOGIN.TEXT.TITLE}
+        </Heading>
+        <LoginForm />
+      </Box>
+    </Center>
+  );
+}

--- a/application/frontend/client/component/templates/MyPageTemplate.tsx
+++ b/application/frontend/client/component/templates/MyPageTemplate.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { Box, Text } from "@chakra-ui/react";
+import HeadingSecond from "@/component/atoms/HeadingSecond";
+import RegulationSheetForm from "@/component/organisms/mypage/RegulationSheetForm";
+import { STYLE } from "@/const/common/STYLE";
+import { STYLE_COLOR } from "@/const/style/STYLE_COLOR";
+import { MYPAGE } from "@/const/pages/MYPAGE";
+
+export default function MyPageTemplate() {
+  return (
+    <Box maxW={STYLE.WIDTH.SECTION} mx="auto" px={6} pt={"calc(60px + 2.5rem)"} pb={16}>
+      <Box mb={8}>
+        <HeadingSecond title={MYPAGE.TEXT.TITLE} />
+        <Text mt={2} fontSize="sm" color={STYLE_COLOR.BLACK} opacity={0.75}>
+          {MYPAGE.TEXT.SUBTITLE}
+        </Text>
+      </Box>
+      <RegulationSheetForm />
+    </Box>
+  );
+}

--- a/application/frontend/client/const/common/COMMON.tsx
+++ b/application/frontend/client/const/common/COMMON.tsx
@@ -1,3 +1,5 @@
 export const COMMON = {
     SITE_NAME: "片翼の大鷲亭",
+    MYPAGE_LABEL: "マイページ",
+    LOGOUT_LABEL: "ログアウト",
 }

--- a/application/frontend/client/const/common/PATH.tsx
+++ b/application/frontend/client/const/common/PATH.tsx
@@ -10,6 +10,8 @@ export const PATH = {
   },
   URL: {
     HOME: "/",
+    MYPAGE: "/mypage",
+    LOGIN: "/login",
     PERIOD: {
       ROOT: "/",
       RACE: "/race",

--- a/application/frontend/client/const/function/calcGrowthGuide.ts
+++ b/application/frontend/client/const/function/calcGrowthGuide.ts
@@ -1,0 +1,33 @@
+import type {
+  GrowthGuideInput,
+  GrowthGuideItemType,
+} from "@/const/type/mypage/GrowthGuideType";
+
+// 成長指示の計算（純粋関数・DB アクセスなし）。
+// ゆとシート値と level_cap しきい値を比較し、条件を満たす指示のみ push する。
+// nullable（expDiff / minGrowth / minHonor）が null の条件は評価しない（指示を出さない）。
+export const calcGrowthGuide = (input: GrowthGuideInput): GrowthGuideItemType[] => {
+  const items: GrowthGuideItemType[] = [];
+
+  // exp: 経験点だけ差分は exp_diff 固定。先頭レベル（expDiff が null）は出さない。
+  if (input.expDiff !== null && input.expTotal < input.minExp) {
+    items.push({ kind: "exp", value: input.expDiff });
+  }
+
+  // growth: しきい値 − 現在値。minGrowth が null なら評価しない。
+  if (input.minGrowth !== null && input.historyGrowTotal < input.minGrowth) {
+    items.push({ kind: "growth", value: input.minGrowth - input.historyGrowTotal });
+  }
+
+  // reward: しきい値 − 現在値。minReward は非 null。
+  if (input.historyMoneyTotal < input.minReward) {
+    items.push({ kind: "reward", value: input.minReward - input.historyMoneyTotal });
+  }
+
+  // honor: しきい値 − 現在値。minHonor が null なら評価しない。
+  if (input.minHonor !== null && input.historyHonorTotal < input.minHonor) {
+    items.push({ kind: "honor", value: input.minHonor - input.historyHonorTotal });
+  }
+
+  return items;
+};

--- a/application/frontend/client/const/function/getLatestScheduledRegulation.ts
+++ b/application/frontend/client/const/function/getLatestScheduledRegulation.ts
@@ -1,0 +1,42 @@
+import { supabase } from "@/lib/supabase";
+import type { LatestScheduledRegulationType } from "@/const/type/mypage/LatestScheduledRegulationType";
+import type { LevelCapScheduleType } from "@/const/type/regulation/LevelCapScheduleType";
+
+// level_cap_schedule が空配列でない（日程登録あり）レギュレーションのうち
+// id 最大を最新として返す（設計「最新レギュレーション判定」準拠）。
+// publish_type = "public" 条件は既存 getRegulationItems に倣う。
+// 該当なしは null を返す。
+export const getLatestScheduledRegulation =
+  async (): Promise<LatestScheduledRegulationType | null> => {
+    const { data, error } = await supabase
+      .from("regulation_items")
+      .select("id, name, level_cap_belt, level_cap_schedule")
+      .eq("publish_type", "public")
+      .order("id", { ascending: false });
+    if (error) throw error;
+
+    for (const row of data ?? []) {
+      // jsonb は any/unknown を使わずランタイムチェックしてマッピングする。
+      if (!Array.isArray(row.level_cap_schedule) || row.level_cap_schedule.length === 0) {
+        continue;
+      }
+
+      const levelCapSchedule: LevelCapScheduleType[] = (
+        row.level_cap_schedule as Record<string, string | number | boolean | null>[]
+      ).map((item) => ({
+        levelCapId: Number(item.levelCapId),
+        level: String(item.level),
+        date: String(item.date),
+      }));
+
+      // id 降順で取得済みのため、最初に見つかったものが最新（id 最大）。
+      return {
+        id: row.id,
+        name: row.name,
+        levelCapBelt: row.level_cap_belt,
+        levelCapSchedule,
+      };
+    }
+
+    return null;
+  };

--- a/application/frontend/client/const/function/getLevelCapItems.ts
+++ b/application/frontend/client/const/function/getLevelCapItems.ts
@@ -17,6 +17,7 @@ export const getLevelCapItems = async (beltType: string): Promise<LevelCapItemTy
     minGrowth: row.min_growth !== null ? Number(row.min_growth) : null,
     minReward: Number(row.min_reward),
     minHonor: row.min_honor !== null ? Number(row.min_honor) : null,
+    expDiff: row.exp_diff !== null ? Number(row.exp_diff) : null,
     maxAdventurerRank: row.max_adventurer_rank,
     rewardAmount: Number(row.reward_amount),
     offBalanceReward: Number(row.off_balance_reward),

--- a/application/frontend/client/const/function/getScheduledRegulations.ts
+++ b/application/frontend/client/const/function/getScheduledRegulations.ts
@@ -1,0 +1,43 @@
+import { supabase } from "@/lib/supabase";
+import type { LatestScheduledRegulationType } from "@/const/type/mypage/LatestScheduledRegulationType";
+import type { LevelCapScheduleType } from "@/const/type/regulation/LevelCapScheduleType";
+
+// level_cap_schedule が空配列でない（日程登録あり）レギュレーションを全件、id 降順で返す。
+// getLatestScheduledRegulation と同じ取得・jsonb マッピング方式を踏襲する
+// （フォームで一覧表示するため「最新のものまで」= schedule ありの全件）。
+// publish_type = "public" 条件は既存 getRegulationItems / getLatestScheduledRegulation に倣う。
+export const getScheduledRegulations =
+  async (): Promise<LatestScheduledRegulationType[]> => {
+    const { data, error } = await supabase
+      .from("regulation_items")
+      .select("id, name, level_cap_belt, level_cap_schedule")
+      .eq("publish_type", "public")
+      .order("id", { ascending: false });
+    if (error) throw error;
+
+    const result: LatestScheduledRegulationType[] = [];
+
+    for (const row of data ?? []) {
+      // jsonb は any/unknown を使わずランタイムチェックしてマッピングする。
+      if (!Array.isArray(row.level_cap_schedule) || row.level_cap_schedule.length === 0) {
+        continue;
+      }
+
+      const levelCapSchedule: LevelCapScheduleType[] = (
+        row.level_cap_schedule as Record<string, string | number | boolean | null>[]
+      ).map((item) => ({
+        levelCapId: Number(item.levelCapId),
+        level: String(item.level),
+        date: String(item.date),
+      }));
+
+      result.push({
+        id: row.id,
+        name: row.name,
+        levelCapBelt: row.level_cap_belt,
+        levelCapSchedule,
+      });
+    }
+
+    return result;
+  };

--- a/application/frontend/client/const/function/getUserRegulationSheet.ts
+++ b/application/frontend/client/const/function/getUserRegulationSheet.ts
@@ -1,0 +1,36 @@
+import type { UserRegulationSheetType } from "@/const/type/mypage/UserRegulationSheetType";
+
+// 本人のゆとシート設定を取得する（設計「DB 操作 / データ取得関数の責務一覧」準拠）。
+//
+// /api/mypage（GET）を同一オリジンで叩き、本人スコープ（セッション user_id）の
+// user_regulation_sheets 相当を受け取る。API は Phase5 で実装。
+// API 側で snake_case → camelCase 変換済みの UserRegulationSheetType[] を JSON で返す前提。
+// （/api/mypage GET の責務として変換を担う。本関数は受領した camelCase をそのまま使う）。
+//
+// 非同期は async/await。エラーは throw（画面側で useErrorHandler が処理する）。
+const MYPAGE_API_PATH = "/api/mypage";
+
+export const getUserRegulationSheet = async (): Promise<UserRegulationSheetType[]> => {
+  const res = await fetch(MYPAGE_API_PATH, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch user regulation sheets: ${res.status}`);
+  }
+
+  // 外部スキーマ保証のため any/unknown を使わずランタイムチェックしてマッピングする。
+  const json: Record<string, string | number | boolean | null>[] = await res.json();
+  if (!Array.isArray(json)) {
+    throw new Error("Invalid response: expected an array of user regulation sheets");
+  }
+
+  return json.map((row) => ({
+    id: Number(row.id),
+    userId: String(row.userId),
+    regulationId: Number(row.regulationId),
+    yutosheetUrl: String(row.yutosheetUrl),
+    note: String(row.note),
+    updatedAt: row.updatedAt !== null && row.updatedAt !== undefined ? String(row.updatedAt) : null,
+  }));
+};

--- a/application/frontend/client/const/function/resolveCurrentLevelCap.ts
+++ b/application/frontend/client/const/function/resolveCurrentLevelCap.ts
@@ -1,0 +1,50 @@
+import { getLevelCapItems } from "@/const/function/getLevelCapItems";
+import type { LevelCapItemType } from "@/const/type/levelCap/LevelCapType";
+import type { LevelCapScheduleType } from "@/const/type/regulation/LevelCapScheduleType";
+
+// 今日（または基準日）が level_cap_schedule のどの level 区間に属するかを判定し、
+// その belt_type + level の level_cap 行を取得する（設計「現在のレベルキャップ解決」準拠）。
+//
+// - schedule を date 昇順ソートし「date <= 基準日」を満たす最後の要素を現在区間とする。
+// - 該当なし（最初の日程より前 = レベルキャップ未開始）は null を返す。
+// - 決まった level と beltType で level_cap 行を取得（なければ null）。
+//
+// baseDate は "YYYY-MM-DD" 文字列。省略時は今日（ローカル日付）。
+export const resolveCurrentLevelCap = async (
+  levelCapSchedule: LevelCapScheduleType[],
+  beltType: string,
+  baseDate?: string
+): Promise<LevelCapItemType | null> => {
+  const today = baseDate ?? formatToday();
+
+  // 1. date 昇順にソート（元配列を破壊しないようコピー）。
+  const sorted = [...levelCapSchedule].sort((a, b) => (a.date <= b.date ? -1 : 1));
+
+  // 2. 「date <= today」を満たす最後の要素を現在区間とする。
+  let current: LevelCapScheduleType | null = null;
+  for (const entry of sorted) {
+    if (entry.date <= today) {
+      current = entry;
+    } else {
+      // ソート済みなので以降はすべて未来。
+      break;
+    }
+  }
+
+  // 3. 最初の日程より前（レベルキャップ未開始）は成長指示なし。
+  if (current === null) return null;
+
+  // 4. belt_type + level で level_cap 行を一意に特定（UNIQUE(belt_type, level)）。
+  const items = await getLevelCapItems(beltType);
+  const matched = items.find((item) => item.level === current.level);
+
+  return matched ?? null;
+};
+
+const formatToday = (): string => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};

--- a/application/frontend/client/const/function/validateYutosheetUrl.ts
+++ b/application/frontend/client/const/function/validateYutosheetUrl.ts
@@ -1,0 +1,37 @@
+// ゆとシート URL 検証（SSRF / XSS 共通ロジック）【最優先・設計 S-1 の正本実装】
+//
+// 用途: 次の 3 経路すべてで本関数を共有する。
+//   - /api/yutosheet（GET）: ゆとシート JSONP 取得時の SSRF 対策（検証通過後にサーバーが
+//     &callback=ytsheetJsonp を付与する。検証 → 付与の順序を守る）。
+//   - /api/mypage（PUT）: ゆとシート URL 保存時の入力検証（不正は 400）。
+//   - 表示時: 成長指示の別タブリンク href 設定時（不正はリンク化しない。javascript:/data: 混入の防止）。
+//
+// 戻り値: 妥当なら URL、不正なら null。any/unknown は使用しない。
+
+const ALLOWED_HOST = "yutorize.work";
+
+export const validateYutosheetUrl = (input: string): URL | null => {
+  // 1. パース。失敗は不正。
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return null;
+  }
+
+  // 2. スキームは https のみ許可（http も不可）。
+  //    これにより javascript: / data: / file: / gopher: / ftp: 等は自動的に弾かれる。
+  if (url.protocol !== "https:") return null;
+
+  // 3. ホストは小文字化したうえで「完全一致」のみ許可。
+  //    includes / startsWith / endsWith は使わない（部分一致のすり抜けを防ぐ）。
+  if (url.hostname.toLowerCase() !== ALLOWED_HOST) return null;
+
+  // 4. userinfo（username / password）付き URL は拒否。
+  if (url.username !== "" || url.password !== "") return null;
+
+  // 5. 非標準ポートは拒否（https 既定の 443 以外。url.port は既定時 "" になる）。
+  if (url.port !== "" && url.port !== "443") return null;
+
+  return url;
+};

--- a/application/frontend/client/const/pages/LOGIN.tsx
+++ b/application/frontend/client/const/pages/LOGIN.tsx
@@ -1,0 +1,16 @@
+export const LOGIN: {
+  TEXT: { [key: string]: string };
+  VALUE: { [key: string]: string | number };
+} = {
+  TEXT: {
+    TITLE: "ログイン",
+    USER_ID_LABEL: "ユーザーID",
+    PASSWORD_LABEL: "パスワード",
+    SUBMIT: "ログイン",
+    ERROR_INVALID: "ユーザーIDまたはパスワードが正しくありません",
+    ERROR_NO_PERMISSION: "このアカウントではマイページを利用できません",
+  },
+  VALUE: {
+    PASSWORD_MIN_LENGTH: 8,
+  },
+} as const;

--- a/application/frontend/client/const/pages/MYPAGE.tsx
+++ b/application/frontend/client/const/pages/MYPAGE.tsx
@@ -1,0 +1,42 @@
+export const MYPAGE: {
+  TEXT: { [key: string]: string };
+  VALUE: { [key: string]: string | number };
+} = {
+  TEXT: {
+    TITLE: "マイページ",
+    SUBTITLE: "キャラクターの登録状況と、最新レギュレーションでの成長指示を確認できます。",
+    LATEST_BADGE: "最新",
+    URL_HELP: "ゆとシートのキャラクターシート URL をそのまま貼り付けてください。",
+    NOTE_HELP: "メモや補足があれば入力してください（任意）。",
+    URL_LABEL: "ゆとシートURL",
+    CHARACTER_LABEL: "キャラクター",
+    CHARACTOR_ROLE_LABEL: "役割",
+    SAVE: "保存",
+    SAVED: "保存しました",
+    EDIT: "編集",
+    CANCEL: "キャンセル",
+    UNREGISTERED: "未登録",
+    INVALID_URL: "ゆとシートURLが正しくありません",
+    GUIDE_LABEL: "成長指示",
+    CURRENT_LEVEL: "現在のレベル帯",
+    GUIDE_DESC: "成長鯖より下記の成長をしてください。",
+    GUIDE_EXP: "経験点",
+    GUIDE_GROWTH: "成長",
+    GUIDE_REWARD: "報酬金額",
+    GUIDE_HONOR: "名誉点",
+    GUIDE_NONE: "現在、成長指示はありません",
+    NO_LATEST: "対象のレギュレーションがありません",
+    NO_URL: "ゆとシートURLが未登録です。「ゆとシート設定」から登録してください",
+  },
+  VALUE: {
+    URL_PLACEHOLDER: "https://yutorize.2-d.jp/ytsheet/sw2.5/?id=XXXXXX",
+    NOTE_PLACEHOLDER: "（任意）",
+    UNIT_EXP: "点",
+    UNIT_GROWTH: "回",
+    UNIT_REWARD: "G",
+    UNIT_HONOR: "点",
+    // JSONP 取得用のコールバッククエリ。コールバック名はサーバー固定の安全な定数（英数字のみ）。
+    // ユーザー入力は一切使わない（コールバック名インジェクション防止）。サーバー側で付与する。
+    YUTOSHEET_JSONP_QUERY: "&callback=ytsheetJsonp",
+  },
+} as const;

--- a/application/frontend/client/const/style/STYLE_COLOR.tsx
+++ b/application/frontend/client/const/style/STYLE_COLOR.tsx
@@ -8,4 +8,6 @@ export const STYLE_COLOR = {
   BLACK: "#2D2D2D",
   COMMON: "#F0FDFF",
   MAIN: "#00E5FF",
+  BORDER: "#BFDBFE",
+  SUCCESS: "#16A34A",
 };

--- a/application/frontend/client/const/type/auth/LoginFormType.ts
+++ b/application/frontend/client/const/type/auth/LoginFormType.ts
@@ -1,0 +1,4 @@
+export type LoginFormType = {
+  userId: string;
+  password: string;
+};

--- a/application/frontend/client/const/type/auth/UserRoleType.ts
+++ b/application/frontend/client/const/type/auth/UserRoleType.ts
@@ -1,0 +1,2 @@
+// client 側のロール union（migration 004 の user_meta_role_check に合わせる）
+export type UserRoleType = "common" | "general" | "admin";

--- a/application/frontend/client/const/type/levelCap/LevelCapType.ts
+++ b/application/frontend/client/const/type/levelCap/LevelCapType.ts
@@ -7,6 +7,7 @@ export type LevelCapItemType = {
   minGrowth: number | null;
   minReward: number;
   minHonor: number | null;
+  expDiff: number | null;
   maxAdventurerRank: string;
   rewardAmount: number;
   offBalanceReward: number;

--- a/application/frontend/client/const/type/mypage/GrowthGuideType.ts
+++ b/application/frontend/client/const/type/mypage/GrowthGuideType.ts
@@ -1,0 +1,26 @@
+export type GrowthGuideKind = "exp" | "growth" | "reward" | "honor";
+
+export type GrowthGuideItemType = {
+  kind: GrowthGuideKind;
+  value: number;
+};
+
+export type GrowthGuideType = {
+  characterName: string;
+  sheetUrl: string;
+  items: GrowthGuideItemType[]; // 条件を満たした指示のみ
+};
+
+// calcGrowthGuide の入力（ゆとシート値 + level_cap しきい値）
+// expDiff / minGrowth / minHonor は nullable（null は評価しない）。
+export type GrowthGuideInput = {
+  expTotal: number;
+  historyGrowTotal: number;
+  historyMoneyTotal: number;
+  historyHonorTotal: number;
+  minExp: number;
+  minGrowth: number | null;
+  minReward: number;
+  minHonor: number | null;
+  expDiff: number | null;
+};

--- a/application/frontend/client/const/type/mypage/LatestScheduledRegulationType.ts
+++ b/application/frontend/client/const/type/mypage/LatestScheduledRegulationType.ts
@@ -1,0 +1,10 @@
+import type { LevelCapScheduleType } from "@/const/type/regulation/LevelCapScheduleType";
+
+// 最新（level_cap_schedule 非空・id 最大）レギュレーションの
+// 成長指示に必要な最小情報。
+export type LatestScheduledRegulationType = {
+  id: number;
+  name: string;
+  levelCapBelt: string;
+  levelCapSchedule: LevelCapScheduleType[];
+};

--- a/application/frontend/client/const/type/mypage/UserRegulationSheetType.ts
+++ b/application/frontend/client/const/type/mypage/UserRegulationSheetType.ts
@@ -1,0 +1,8 @@
+export type UserRegulationSheetType = {
+  id: number;
+  userId: string;
+  regulationId: number;
+  yutosheetUrl: string;
+  note: string;
+  updatedAt: string | null;
+};

--- a/application/frontend/client/const/type/mypage/YutosheetJsonType.ts
+++ b/application/frontend/client/const/type/mypage/YutosheetJsonType.ts
@@ -1,0 +1,7 @@
+export type YutosheetJsonType = {
+  characterName: string;
+  expTotal: number;
+  historyGrowTotal: number;
+  historyMoneyTotal: number;
+  historyHonorTotal: number;
+};

--- a/application/frontend/client/const/type/regulation/LevelCapScheduleType.ts
+++ b/application/frontend/client/const/type/regulation/LevelCapScheduleType.ts
@@ -1,0 +1,7 @@
+// regulation_items.level_cap_schedule（jsonb）の1要素。
+// 形: [{ levelCapId: number, level: string, date: "YYYY-MM-DD" }]
+export type LevelCapScheduleType = {
+  levelCapId: number;
+  level: string;
+  date: string;
+};

--- a/application/frontend/client/lib/supabase.ts
+++ b/application/frontend/client/lib/supabase.ts
@@ -1,6 +1,6 @@
-import { createClient } from "@supabase/supabase-js";
+import { createBrowserClient } from "@supabase/ssr";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createBrowserClient(supabaseUrl, supabaseAnonKey);

--- a/application/frontend/client/lib/supabaseAdmin.ts
+++ b/application/frontend/client/lib/supabaseAdmin.ts
@@ -1,0 +1,7 @@
+// API Route 専用。"use client" コンポーネント・middleware から import 禁止（Service Role Key 漏洩防止）。
+import { createClient } from "@supabase/supabase-js";
+
+export const supabaseAdmin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);

--- a/application/frontend/client/middleware.ts
+++ b/application/frontend/client/middleware.ts
@@ -1,0 +1,101 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import type { UserRoleType } from "@/const/type/auth/UserRoleType";
+
+// マイページ機能の認可は user_meta.role の allowlist（フェイルクローズ）で行う。
+// general / admin に厳密一致した場合のみ許可し、それ以外（common / null / 未知 / 取得失敗 / 例外）は全拒否する。
+const ALLOWED_ROLES: readonly UserRoleType[] = ["general", "admin"];
+
+// オープンリダイレクト予防のため、遷移先は内部固定パスのリテラルのみを使用する。
+const LOGIN_PATH = "/login";
+const MYPAGE_PATH = "/mypage";
+
+export async function middleware(request: NextRequest) {
+  const response = NextResponse.next();
+  const pathname = request.nextUrl.pathname;
+  const isApiRoute = pathname.startsWith("/api/");
+  const isLoginPath = pathname === LOGIN_PATH;
+
+  // Edge Runtime: anon key 経由でセッション・role を検証する。Service Role Key は使用しない。
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll: () => request.cookies.getAll(),
+        setAll: (cookiesToSet) => {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            response.cookies.set(name, value, options);
+          });
+        },
+      },
+    }
+  );
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // 未認証
+  if (!user) {
+    if (isLoginPath) {
+      return response;
+    }
+    if (isApiRoute) {
+      return NextResponse.json(
+        { error: "認証が必要です", code: "UNAUTHORIZED" },
+        { status: 401 }
+      );
+    }
+    return NextResponse.redirect(new URL(LOGIN_PATH, request.url));
+  }
+
+  // セッションあり → user_meta から role を取得（anon key・本人 RLS）。
+  // 取得失敗・例外も含めフェイルクローズで評価するため、role を文字列または null に正規化する。
+  let role: string | null = null;
+  try {
+    const { data: userMeta } = await supabase
+      .from("user_meta")
+      .select("role")
+      .eq("id", user.id)
+      .single<{ role: string | null }>();
+    role = userMeta?.role ?? null;
+  } catch {
+    role = null;
+  }
+
+  const allowed =
+    typeof role === "string" &&
+    (ALLOWED_ROLES as readonly string[]).includes(role);
+
+  // /login にセッションあり かつ 許可ロール → /mypage へ
+  if (isLoginPath) {
+    if (allowed) {
+      return NextResponse.redirect(new URL(MYPAGE_PATH, request.url));
+    }
+    return response;
+  }
+
+  // 保護対象（/mypage・client API）でロール許可外 → フェイルクローズ拒否
+  if (!allowed) {
+    if (isApiRoute) {
+      return NextResponse.json(
+        { error: "権限がありません", code: "FORBIDDEN" },
+        { status: 403 }
+      );
+    }
+    return NextResponse.redirect(new URL(LOGIN_PATH, request.url));
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    "/mypage/:path*",
+    "/api/mypage/:path*",
+    "/api/yutosheet/:path*",
+    "/login",
+  ],
+};

--- a/application/frontend/client/package-lock.json
+++ b/application/frontend/client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@chakra-ui/react": "^3.33.0",
         "@emotion/react": "^11.14.0",
+        "@supabase/ssr": "^0.10.3",
         "@supabase/supabase-js": "^2.106.2",
         "next": "^16.1.6",
         "react": "19.1.0",
@@ -1887,6 +1888,18 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/ssr": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.10.3.tgz",
+      "integrity": "sha512-ux2CJgX89h0Fz2lY7ZNafNG2SkXpyRc5dz77K9eKeBLPdtywQixKwIuetDeIViAJBp/buOUVmgj8PVesOklNpw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.105.3"
       }
     },
     "node_modules/@supabase/storage-js": {
@@ -3947,6 +3960,19 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",

--- a/application/frontend/client/package.json
+++ b/application/frontend/client/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@chakra-ui/react": "^3.33.0",
     "@emotion/react": "^11.14.0",
+    "@supabase/ssr": "^0.10.3",
     "@supabase/supabase-js": "^2.106.2",
     "next": "^16.1.6",
     "react": "19.1.0",

--- a/docs/client/design/00_overview.md
+++ b/docs/client/design/00_overview.md
@@ -1,0 +1,258 @@
+# client マイページ機能 全体設計
+
+## 概要
+
+Issue: https://github.com/seika-777/eagle/issues/45
+
+`application/frontend/client/` の Next.js プロジェクトに、ログイン中ユーザー向けの **マイページ機能** を追加する。
+ユーザーはレギュレーションごとに自分のゆとシート（キャラクターシート）URL・備考を登録でき、
+最新レギュレーションのレベルキャップスケジュールとゆとシート JSON をもとに「成長指示」を確認できる。
+
+admin 側（`docs/admin/design/`）と同じ Supabase データベース・認証方式（Supabase Auth + `user_meta`）を共有する。
+
+---
+
+## 実装機能一覧
+
+| # | 機能 | 設計ファイル |
+|---|------|------------|
+| 1 | ログイン／認証・ロール制御 | [01_auth.md](./01_auth.md) |
+| 2 | マイページ画面 | [02_mypage.md](./02_mypage.md) |
+| 3 | DB 変更（差分カラム追加・ユーザー別ゆとシート設定テーブル） | [03_migration.md](./03_migration.md) |
+
+---
+
+## ベータ版に関する方針（重要）
+
+本機能は **ベータ版** としてリリースする。以下の制約を設ける。
+
+- **ナビゲーション等に「ログイン画面（`/login`）への遷移ボタン」は設置しない。**
+  ユーザーは `/login` を **直接 URL でアクセス** する想定。トップページ・ヘッダー・フッター等からの導線は本リリースでは追加しない。
+- ただし以下は本 Issue で実装する。
+  - ログイン画面（`/login`）
+  - Supabase 認証（ユーザー ID + パスワード）
+  - ロール（`general` / `admin`）による マイページ表示制御
+  - 認証ガード（`middleware.ts`）
+- マイページ（`/mypage`）も直接 URL アクセスを想定する。未認証・権限外のアクセスは `middleware.ts` で `/login` へリダイレクトする（詳細は [01_auth.md](./01_auth.md)）。
+
+> この「ログイン導線を設けない」方針は本 00_overview.md と [01_auth.md](./01_auth.md) の両方に明記する。将来の正式版でナビゲーションへのログイン導線追加を検討する。
+
+---
+
+## 技術スタック
+
+`application/frontend/client/package.json`（version `"0.1.0"`）の実値に基づく。
+
+| カテゴリ | 技術・バージョン |
+|---------|------|
+| フレームワーク | Next.js `^16.1.6`（App Router / `next dev --turbopack`） |
+| UI ライブラリ | React `19.1.0` / react-dom `19.1.0` |
+| 言語 | TypeScript `^5` |
+| UI | @chakra-ui/react `^3.33.0` + @emotion/react `^11.14.0` |
+| アイコン | react-icons `^5.5.0` |
+| スタイル | sass `^1.90.0` |
+| DB クライアント | @supabase/supabase-js `^2.106.2` |
+| 認証 | Supabase Auth（ユーザー ID + パスワード）+ `user_meta` テーブル |
+
+> **新規追加が必要な依存**: `middleware.ts` の認証ガードで `@supabase/ssr` の `createServerClient`（Edge Runtime 対応）を使用する。
+> admin 側と同様、client の `package.json` に `@supabase/ssr` を追加する（現状未導入）。バージョンは実装時に admin 側のロックと揃える。
+
+---
+
+## 現状（追加が必要なファイル）
+
+client には現状、以下が **存在しない**。本 Issue で追加する。
+
+| パス | 用途 | 状態 |
+|------|------|------|
+| `middleware.ts` | 認証ガード（Edge Runtime） | 新規 |
+| `lib/supabaseAdmin.ts` | API Route 用（Service Role Key）。**API Route からのみ import 可。`"use client"`・`middleware.ts` からは import 禁止** | 新規 |
+| `app/login/page.tsx` | ログイン画面 | 新規 |
+| `app/mypage/page.tsx` | マイページ画面 | 新規 |
+| `app/api/auth/route.ts` | 認証 API（login） | 新規 |
+| `app/api/mypage/route.ts` | ゆとシート設定の保存・取得 API | 新規 |
+| `app/api/yutosheet/route.ts` | ゆとシート JSON プロキシ取得 API | 新規 |
+
+既存の `lib/supabase.ts`（anon key クライアント。`import { supabase } from "@/lib/supabase"`）はそのまま利用する。
+
+---
+
+## データモデル概要
+
+| テーブル | 役割 | 本 Issue での変更 |
+|---------|------|------------------|
+| `auth.users` | Supabase Auth ユーザー | 変更なし |
+| `user_meta` | プロフィール（`user_id` / `display_name` / `role` / `is_editable`） | 変更なし（参照のみ）。`role` の CHECK は migration 004 で `('common','general','admin')` に拡張済み |
+| `regulation_items` | レギュレーション。`level_cap_schedule`(jsonb) を含む（migration 009 追加済み） | 変更なし（参照のみ） |
+| `level_cap` | レベルキャップ値（migration 008 が最新定義） | **差分カラム `exp_diff` を ALTER で追加**（[03_migration.md](./03_migration.md)） |
+| `user_regulation_sheets` | **新規**: ユーザー×レギュレーションのゆとシート URL・備考 | **新規作成**（[03_migration.md](./03_migration.md)） |
+
+### マイページ表示対象ロール
+
+| role | マイページ（`/mypage`）アクセス |
+|------|------|
+| 未認証 | 不可（`/login` へリダイレクト） |
+| `"common"` | 不可（`/login` へリダイレクト） |
+| `"general"` | 可 |
+| `"admin"` | 可 |
+
+---
+
+## ディレクトリ構成（実装後）
+
+アトミックデザインを踏襲する。既存構成（`app/[period]/page.tsx` 等）はそのまま残す。
+
+```
+application/frontend/client/
+├── app/
+│   ├── login/
+│   │   └── page.tsx                    # ログイン画面（新規）
+│   ├── mypage/
+│   │   └── page.tsx                    # マイページ画面（新規）
+│   └── api/
+│       ├── auth/
+│       │   └── route.ts                # 認証（action: "login"）（新規）
+│       ├── mypage/
+│       │   └── route.ts                # ゆとシート設定 GET / PUT（新規）
+│       └── yutosheet/
+│           └── route.ts                # ゆとシート JSON プロキシ GET（新規）
+├── component/
+│   ├── atoms/
+│   ├── molecules/
+│   │   └── field/
+│   │       └── TextInputField.tsx      # （admin 命名に準拠。なければ新規）
+│   ├── organisms/
+│   │   ├── login/
+│   │   │   └── LoginForm.tsx           # ログインフォーム（新規）
+│   │   └── mypage/
+│   │       ├── RegulationSheetForm.tsx # ゆとシート URL・備考 編集（新規）
+│   │       └── GrowthGuide.tsx         # 成長指示の表示（新規）
+│   └── templates/
+│       ├── LoginTemplate.tsx           # ログイン画面テンプレート（新規）
+│       └── MyPageTemplate.tsx          # マイページテンプレート（新規）
+├── const/
+│   ├── common/
+│   ├── font/
+│   ├── pages/
+│   │   ├── LOGIN.tsx                    # ログイン画面文言（新規）
+│   │   └── MYPAGE.tsx                   # マイページ画面文言（新規）
+│   ├── style/
+│   ├── function/
+│   │   ├── getLatestScheduledRegulation.ts  # 最新（日程登録あり）レギュレーション取得（新規）
+│   │   ├── getUserRegulationSheet.ts        # ユーザーのゆとシート設定取得（新規）
+│   │   ├── resolveCurrentLevelCap.ts        # 現在日付が属する level_cap 行の解決（新規）
+│   │   └── calcGrowthGuide.ts               # 成長指示計算（新規）
+│   └── type/
+│       ├── auth/
+│       │   ├── LoginFormType.ts        # （新規）
+│       │   └── UserRoleType.ts         # "common" | "general" | "admin"（新規）
+│       ├── mypage/
+│       │   ├── UserRegulationSheetType.ts  # （新規）
+│       │   ├── YutosheetJsonType.ts        # ゆとシート JSON（新規）
+│       │   └── GrowthGuideType.ts          # 成長指示（新規）
+│       └── levelCap/
+│           └── LevelCapType.ts         # 既存。exp_diff 追加に伴い expDiff を追加
+├── hooks/
+│   └── useErrorHandler.ts              # 既存
+└── lib/
+    ├── supabase.ts                     # 既存（anon key）
+    └── supabaseAdmin.ts                # 新規（Service Role Key・API Route 専用）
+```
+
+> **規約準拠メモ**:
+> - 型は `const/type/<機能>/XxxType.ts` に配置（const 直下に型を置かない・1 機能 1 ディレクトリ）。
+> - import は絶対パス `@/`。
+> - 画面文言は `const/pages/XXX.tsx` に `{ TEXT: {...}, VALUE: {...} } as const` で定義。
+> - 定数は 1 ファイル 1 定数・ファイル名 UPPER_CASE.tsx。
+> - 非同期は async/await、Props は `type Props`、return 文は 1 つ、エラー処理は `useErrorHandler`、`any`/`unknown` 禁止。
+
+---
+
+## API Route 設計（概要）
+
+DB 書き込み・外部 fetch はすべて API Route 経由とし、フロントに Service Role Key を露出させない。
+エラーレスポンスは admin と同じ形式・HTTP ステータス規約に揃え、**`{ error, code }` 固定**で upstream 本文・スタックトレース・内部詳細を含めない。
+外部プロキシ（`/api/yutosheet`）は **ホワイトリストフィールドのみ返却**する（生 JSON 全体の転送禁止）。詳細は「## セキュリティ要件」を参照。
+
+```typescript
+// 共通エラーレスポンス型（admin と同一）
+type ErrorResponse = {
+  error: string; // ユーザー表示用メッセージ
+  code: string;  // フロントの条件分岐用
+};
+```
+
+| HTTP | code | 用途 |
+|------|------|------|
+| 400 | `"BAD_REQUEST"` | パラメータ不正 |
+| 401 | `"UNAUTHORIZED"` | 未認証 |
+| 403 | `"FORBIDDEN"` | ロール権限不足（`general`/`admin` 以外） |
+| 404 | `"NOT_FOUND"` | 対象レギュレーション・最新レギュレーションなし |
+| 502 | `"UPSTREAM_ERROR"` | ゆとシート外部取得失敗 |
+| 500 | `"INTERNAL_ERROR"` | サーバー内部エラー |
+
+| エンドポイント | メソッド | 処理 |
+|----------------|---------|------|
+| `/api/auth`（action:"login"） | POST | user_id → email 解決 + signInWithPassword |
+| `/api/mypage` | GET | ログインユーザーの `user_regulation_sheets` を取得 |
+| `/api/mypage` | PUT | `user_regulation_sheets` を upsert（本人分のみ） |
+| `/api/yutosheet` | GET | ゆとシート URL の JSONP（`&callback=ytsheetJsonp`）をサーバーサイドで取得しラッパー除去 → JSON.parse（CORS 回避プロキシ。詳細は [02_mypage.md](./02_mypage.md)） |
+
+詳細は [01_auth.md](./01_auth.md) / [02_mypage.md](./02_mypage.md) を参照。
+
+---
+
+## マイグレーション実行順序
+
+既存の番号体系（009 が最新）に続けて連番で追加する。
+
+```
+... 009_add_regulation_schedule.sql       → 既存（最新）
+010_add_mypage.sql                        → level_cap に exp_diff カラム追加 + 既存行 UPDATE / user_regulation_sheets 新規作成 + RLS（exp_diff 追加 + user_regulation_sheets 作成 を1ファイルに統合・新規）
+```
+
+> 番号は必ず連番・依存順で実行する。詳細は [03_migration.md](./03_migration.md)。
+
+---
+
+## 実装順序（案）
+
+1. 共通基盤: `lib/supabaseAdmin.ts` / `@supabase/ssr` 導入 / `middleware.ts`
+2. DB 変更: migration 010_add_mypage.sql（exp_diff 追加 + user_regulation_sheets 作成 を1ファイルに統合）
+3. ログイン機能（`/login`・`/api/auth`・ロール判定）
+4. マイページ データ取得関数群（`const/function/`）と型
+5. マイページ画面（ゆとシート URL/備考 編集 → 成長指示表示）
+6. ゆとシート JSON プロキシ API（`/api/yutosheet`）
+
+---
+
+## セキュリティ要件（概要）
+
+セキュリティレビュー結果を反映した要件の一覧。**詳細・擬似コードは各設計書の「## セキュリティ要件」を正本**とし、本節はサマリと参照のみとする。
+
+| # | 項目 | 深刻度 | 正本 |
+|---|------|--------|------|
+| 1 | SSRF: ゆとシート URL 検証（https + `yutorize.2-d.jp` **完全一致**。`includes`/`startsWith`/`endsWith` 禁止・userinfo/非標準ポート拒否） | 最優先 | [02_mypage.md](./02_mypage.md) S-1 |
+| 2 | プロキシ fetch: `redirect: "manual"`・内部IP帯拒否・タイムアウト/サイズ上限/GET固定/JavaScript・JSON 系限定・外部レスポンスをスクリプト実行しない（eval/Function/script 禁止・文字列処理でラッパー除去 → JSON.parse） | 最優先 | [02_mypage.md](./02_mypage.md) S-2 |
+| 3 | 保存URLのスキーム/ドメイン検証（保存時400・表示時リンク化しない。`javascript:`/`data:` 排除） | High | [02_mypage.md](./02_mypage.md) S-1 / [03_migration.md](./03_migration.md) |
+| 4 | 本人スコープ（GET/PUT とも user_id はセッションのみ）・role フェイルクローズ allowlist | High | [01_auth.md](./01_auth.md) S-1/S-2 |
+| 5 | Cookie 属性（HttpOnly/Secure/SameSite）・CSRF（Origin/Referer 検証） | Medium | [01_auth.md](./01_auth.md) S-3 |
+| 6 | ログイン総当たり対策（レート制限/バックオフ）・タイミング平準化 | Medium | [01_auth.md](./01_auth.md) S-4 |
+| 7 | プロキシ応答最小化（ホワイトリスト返却）・エラー秘匿（`{ error, code }` 固定） | Medium | [02_mypage.md](./02_mypage.md) S-3 |
+| 8 | 入力検証（`regulationId` 集合検証・`note`/`yutosheet_url` 最大長） | Medium | [02_mypage.md](./02_mypage.md) S-4 / [03_migration.md](./03_migration.md) |
+| 9 | オープンリダイレクト予防（内部固定パスのリテラルのみ） | Medium | [01_auth.md](./01_auth.md) S-5 |
+| 10 | シークレット/権限境界の明文化 | Info/Low | [01_auth.md](./01_auth.md) S-6 |
+
+### 横断的な権限境界（明文化）
+
+- `lib/supabaseAdmin.ts`（Service Role Key）は **API Route からのみ import**。`"use client"` コンポーネント・`middleware.ts` からは **絶対に import しない**。
+- 権限境界は **`user_meta.role` のみ**であり、role の改変は **Supabase コンソール／Service Role 経由に限定**される。
+- `updated_by` / `user_id` は常にセッション由来でセットし、リクエストボディ指定は無視する。
+
+---
+
+## 未確定・要確認事項
+
+- ゆとシート JSON の `expTotal` / `historyGrowTotal` / `historyMoneyTotal` / `historyHonorTotal` の **フィールド存在・型は未確認**（公式ドキュメント一覧に記載なし）。詳細は [02_mypage.md](./02_mypage.md)。
+- `level_cap` の差分カラム先頭行の扱いは **NULL に確定**（先頭レベルは差分が定義できないため null とし計算側で評価しない。詳細は [03_migration.md](./03_migration.md)）。
+- 「最新レギュレーション」の具体判定条件（詳細は [02_mypage.md](./02_mypage.md)）。

--- a/docs/client/design/01_auth.md
+++ b/docs/client/design/01_auth.md
@@ -1,0 +1,293 @@
+# ログイン／認証・ロール制御 設計
+
+## 概要
+
+client のマイページ機能にアクセスするための認証機能。
+**ユーザー ID + パスワード** でログインする。
+マイページ（`/mypage`）は role が `"general"` または `"admin"` のユーザーのみアクセスできる。
+
+admin 側（`docs/admin/design/01_login.md` / `00_overview.md`）の認証方式を踏襲する。
+Supabase Auth の内部メールは `{userId}@eagle-admin.internal` 形式（admin と共通の `user_meta` を使用するため、admin と同じドメインを用いる）。
+
+---
+
+## ベータ版に関する方針（重要・再掲）
+
+- **ログイン画面（`/login`）への遷移ボタンはナビゲーション等に設置しない。**
+  ユーザーは `/login` を **直接 URL でアクセス** する想定。
+- マイページ（`/mypage`）も直接 URL アクセスを想定し、未認証・権限外は `middleware.ts` で `/login` へリダイレクトする。
+- ログイン画面・認証・ロール判定の実装そのものは本 Issue で行う（導線のみ設けない）。
+
+---
+
+## 画面構成
+
+| 画面 | パス | 説明 |
+|------|------|------|
+| ログイン画面 | `/login` | ユーザー ID・パスワード入力フォーム |
+
+> サインアップ・パスワードリセットは本 Issue のスコープ外（admin 側で運用済み。client では `/login` のみ）。
+
+### ページ・コンポーネント構成
+
+```
+app/login/
+└── page.tsx                          # ログインページ
+
+component/
+├── templates/
+│   └── LoginTemplate.tsx             # ログイン画面テンプレート
+└── organisms/
+    └── login/
+        └── LoginForm.tsx             # ログインフォーム
+```
+
+---
+
+## ログインフォーム仕様
+
+### 入力項目
+
+| フィールド | コンポーネント | バリデーション |
+|-----------|--------------|--------------|
+| ユーザー ID | `TextInputField` | 必須 |
+| パスワード | `TextInputField`（type=password） | 必須・8 文字以上 |
+
+### アクション
+
+| アクション | 処理 |
+|-----------|------|
+| ログインボタン押下 | API Route `/api/auth`（action: "login"）を呼び出し |
+| 成功（role = `"general"` / `"admin"`） | `/mypage` へリダイレクト |
+| 成功（role = `"common"`） | `/login` に留まりエラー表示（マイページ権限なし）。`LOGIN.TEXT.ERROR_NO_PERMISSION` |
+| 失敗 | エラーメッセージ表示（`LOGIN.TEXT.ERROR_INVALID`） |
+
+### API Route: `/api/auth`（action: "login"）
+
+```
+1. user_meta テーブルから user_id に対応するレコードを取得
+2. 存在しない場合 → 401 エラー（"ユーザーIDまたはパスワードが正しくありません" で統一し、user_id 存在有無を漏洩させない）
+3. email（{userId}@eagle-admin.internal）を組み立て
+4. Supabase Auth signInWithPassword({ email, password }) を呼び出し
+5. 成功 → user_meta.role を確認し、role をレスポンスに含めて返す
+6. 失敗 → 401 エラー（ステップ2と同一メッセージ）
+```
+
+> **設計メモ（セキュリティ）**: user_id 不存在・パスワード誤りのいずれも同一の 401 メッセージ（`LOGIN.TEXT.ERROR_INVALID`）を返し、ユーザー列挙攻撃を防止する（admin 同様）。
+> role が `"common"` でも 200 + role を返し、ロール別アクセス制御は **middleware と画面遷移先** で行う（API はセッションを発行する）。
+> **総当たり対策・タイミング平準化・Cookie 属性・Origin 検証・オープンリダイレクト予防は後述「## セキュリティ要件」を参照**。
+
+リクエスト/レスポンス例:
+
+```typescript
+// POST /api/auth
+{ action: "login", userId: string, password: string }
+
+// 200 レスポンス
+{ role: "general" | "admin" | "common" }
+```
+
+---
+
+## 認証ガード（middleware.ts）
+
+`middleware.ts` でセッションを検証し、未認証・権限外のアクセスをリダイレクトする。
+admin 同様、Edge Runtime で動作するため **`@supabase/ssr` の `createServerClient`** を使用する（`lib/supabaseAdmin.ts` は API Route 専用で middleware では使用しない）。
+
+### ロール確認方法
+
+リクエストごとに `user_meta` テーブルを anon key 経由でクエリして role を確認する
+（client のマイページ利用者数・リクエスト数は少ないため DB アクセスのオーバーヘッドは許容範囲）。
+
+### ロール別アクセス制御
+
+| role | アクセス可能ページ | それ以外へのアクセス時 |
+|------|-----------------|-------------------|
+| 未認証 | `/login`（と既存の公開ページ） | `/mypage` 等の保護ページ → `/login` にリダイレクト |
+| `"common"` | 公開ページ（既存）。`/mypage` は不可 | `/mypage` → `/login` にリダイレクト |
+| `"general"` | 公開ページ + `/mypage` | - |
+| `"admin"` | 公開ページ + `/mypage` | - |
+
+> **既存公開ページ（`/[period]` 等）への影響**: client は元々ログイン不要の公開サイトであり、`middleware.ts` の保護対象は **`/mypage` と client 用 API（`/api/mypage`・`/api/yutosheet`）に限定** する。既存の公開ページ・既存 API はガード対象外とし、ベータ版での挙動変更を避ける。
+
+```typescript
+// middleware.ts（イメージ・擬似コード。実装コードではない）
+// 保護対象パス: ["/mypage", "/api/mypage", "/api/yutosheet"]
+//
+// 1. パスが保護対象でなければ何もしない（公開ページはそのまま）
+// 2. @supabase/ssr の createServerClient でセッション確認
+//    - セッションなし かつ API ルート → 401 { error, code: "UNAUTHORIZED" }
+//    - セッションなし かつ /mypage     → /login にリダイレクト
+// 3. セッションあり → user_meta から role を取得（anon key 経由）
+//    - allowlist（"general" | "admin" 厳密一致）以外（"common"/null/未知/取得失敗/例外）は
+//      フェイルクローズで拒否（「## セキュリティ要件」S-2）
+//    - 拒否 かつ API ルート → 403 { error, code: "FORBIDDEN" }
+//    - 拒否 かつ /mypage    → /login にリダイレクト
+// 4. /login アクセス時にセッションあり かつ role が general/admin → /mypage にリダイレクト（任意）
+
+export const config = {
+  matcher: ["/mypage/:path*", "/api/mypage/:path*", "/api/yutosheet/:path*", "/login"],
+};
+```
+
+> **Edge Runtime 注意**: middleware での role チェックは Service Role Key を使わず anon key 経由の `user_meta` クエリで行う。`lib/supabaseAdmin.ts`（Service Role Key）は API Route 専用。
+
+---
+
+## API Route 共通の認証確認（多重防御）
+
+`/api/mypage`・`/api/yutosheet` は middleware で保護されるが、各 Route ハンドラ内でも Cookie のセッションを再検証する（middleware の二重保護）。
+
+```
+1. リクエスト Cookie からセッションを取得（@supabase/ssr）
+2. セッションなし → 401 { error, code: "UNAUTHORIZED" }
+3. user_meta.role を取得し、allowlist（"general" または "admin" に厳密一致）以外は
+   すべて 403 { error, code: "FORBIDDEN" }（フェイルクローズ。詳細は「## セキュリティ要件」S-2）
+4. 以降の処理では auth.uid()（= user_regulation_sheets.user_id）を「本人」として扱う
+```
+
+> **本人スコープの担保**: `/api/mypage` は **GET / PUT のいずれも**、入力（クエリ／ボディ）から user_id を一切受け取らず、**セッションから取得した user_id のみ** で `.eq("user_id", sessionUserId)` する（リクエスト由来の user_id は無視）。あわせて DB 側で RLS（`auth.uid() = user_id`）でも本人に限定する（[03_migration.md](./03_migration.md)）。詳細は「## セキュリティ要件」S-1 を参照。
+
+---
+
+## ログアウト
+
+マイページのヘッダー等にログアウトボタンを配置する（ベータ版でもログアウト導線は許可。「ログイン導線を設けない」制約はログイン画面への遷移ボタンのみが対象）。
+
+- フロントから `supabase.auth.signOut()`（anon key クライアント）を直接呼び出す
+- 成功後 `/login` にリダイレクト
+
+---
+
+## 型定義
+
+```typescript
+// const/type/auth/UserRoleType.ts
+// client 側のロール union（migration 004 の CHECK に合わせる）
+export type UserRoleType = "common" | "general" | "admin";
+```
+
+```typescript
+// const/type/auth/LoginFormType.ts
+export type LoginFormType = {
+  userId: string;
+  password: string;
+};
+```
+
+---
+
+## 画面定数（ログイン）
+
+```typescript
+// const/pages/LOGIN.tsx
+export const LOGIN: {
+  TEXT: { [key: string]: string };
+  VALUE: { [key: string]: string | number };
+} = {
+  TEXT: {
+    TITLE: "ログイン",
+    USER_ID_LABEL: "ユーザーID",
+    PASSWORD_LABEL: "パスワード",
+    SUBMIT: "ログイン",
+    ERROR_INVALID: "ユーザーIDまたはパスワードが正しくありません",
+    ERROR_NO_PERMISSION: "このアカウントではマイページを利用できません",
+  },
+  VALUE: {
+    PASSWORD_MIN_LENGTH: 8,
+  },
+} as const;
+```
+
+---
+
+## Supabase クライアント初期化
+
+```typescript
+// lib/supabase.ts（既存・フロントエンド用 anon key）
+import { supabase } from "@/lib/supabase";
+
+// lib/supabaseAdmin.ts（新規・API Route 専用・Edge Runtime では使用不可）
+import { createClient } from "@supabase/supabase-js";
+export const supabaseAdmin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+```
+
+### 環境変数（追記）
+
+```
+# application/frontend/client/.env.local
+NEXT_PUBLIC_SUPABASE_URL=...       # 既存
+NEXT_PUBLIC_SUPABASE_ANON_KEY=...  # 既存
+SUPABASE_SERVICE_ROLE_KEY=...      # 新規（API Route の DB 書き込みで使用）
+```
+
+---
+
+## DB 操作関数の責務一覧（認証関連）
+
+| 関数 / 配置 | 責務 |
+|-------------|------|
+| `/api/auth` route | login（user_id→email 解決・signInWithPassword・role 返却） |
+| `middleware.ts` | セッション検証・role による `/mypage`・client API のガード |
+| 各 client API route | セッション再検証・本人スコープ確定 |
+
+---
+
+## セキュリティ要件
+
+> 認証・認可・セッションに関するセキュリティ設計。URL 検証・SSRF・プロキシ応答最小化は [02_mypage.md](./02_mypage.md)「## セキュリティ要件」を正本とする。
+> 以下の擬似コードはすべて **設計上のイメージであり実装コードではない**。
+
+### S-1. 本人スコープ（user_id はセッションのみ）【High】
+
+`/api/mypage` の **GET / PUT のいずれも**、入力（クエリ／ボディ）から user_id を一切受け取らない。常にセッション user_id のみで `.eq("user_id", sessionUserId)` する。`updated_by` / `user_id` は常にセッション由来でセットし、リクエストボディ指定は無視する。
+
+### S-2. フェイルクローズ認可（role allowlist）【High】
+
+role 判定は **全経路（middleware・各 API Route）** で allowlist 方式に統一する。
+
+- `role === "general"` または `role === "admin"` に **厳密一致した場合のみ許可**。
+- それ以外（`null` / `"common"` / 未知文字列 / `user_meta` 取得失敗 / 例外）は **すべて拒否**（フェイルクローズ）。
+  - API ルート → 403 `{ error, code: "FORBIDDEN" }`
+  - `/mypage` → `/login` にリダイレクト
+
+```
+// 擬似コード（実装コードではない）
+const ALLOWED_ROLES = ["general", "admin"] as const;
+// role 取得に失敗・例外・null・未知文字列 → 拒否（deny by default）
+const allowed =
+  typeof role === "string" &&
+  (ALLOWED_ROLES as readonly string[]).includes(role);
+if (!allowed) { /* 403 または /login リダイレクト */ }
+```
+
+### S-3. Cookie セッション属性・CSRF 対策【Medium】
+
+- セッション Cookie は **`HttpOnly` / `Secure` / `SameSite=Lax`（または `Strict`）** を設定する（`@supabase/ssr` の Cookie 設定で指定）。
+- 状態変更系 API（`/api/mypage` PUT）は **Origin / Referer による同一オリジン検証** を行う。許可オリジンと一致しない場合は 403。
+
+### S-4. 総当たり対策・タイミング平準化【Medium】
+
+- `/api/auth` に **IP 単位・ユーザー単位のレート制限**と**連続失敗時のバックオフ**を設ける（ベータでも最低限）。
+- user_id 不在時も **Auth 呼び出し相当の処理を通す**等で **応答時間を平準化**し、タイミング攻撃によるユーザー存在推測を防ぐ（既存の同一 401 メッセージ方針と併用）。
+
+### S-5. オープンリダイレクト予防【Medium】
+
+- リダイレクト先は **許可済み内部固定パスのリテラルのみ**（`/login` / `/mypage`）。
+- `next` / `redirect` 等の **ユーザー入力由来の遷移先・外部 URL は使用禁止**。クエリ等から遷移先を組み立てない。
+
+### S-6. シークレット／権限境界【Info/Low】
+
+- `lib/supabaseAdmin.ts`（Service Role Key）は **API Route からのみ import** する。`"use client"` コンポーネント・`middleware.ts` からは **絶対に import しない**（middleware は anon key 経由で role を確認する）。
+- 権限境界は **`user_meta.role` のみ**。role の改変は **Supabase コンソール／Service Role 経由に限定**され、一般ユーザー操作では変更不可。
+- `updated_by` / `user_id` は常にセッション由来でセットし、リクエストボディ指定は無視（S-1 再掲）。
+
+---
+
+## 未確定・要確認事項
+
+- 内部メールドメイン（`@eagle-admin.internal`）を client でもそのまま用いるか（admin/client で `user_meta` を共有する前提では同一が自然）。実装前に admin 側の運用と整合を確認。
+- `middleware.ts` の matcher 範囲（`/mypage` と client API のみに限定する方針）で既存公開ページへの副作用がないか、実装時に E2E で確認。

--- a/docs/client/design/02_mypage.md
+++ b/docs/client/design/02_mypage.md
@@ -1,0 +1,500 @@
+# マイページ画面 設計
+
+## 概要
+
+ログイン中ユーザー（role = `general` / `admin`）が利用するマイページ。
+レギュレーションごとに自分の **ゆとシート URL・備考** を登録でき、
+**最新レギュレーション** のレベルキャップスケジュールとゆとシート JSON をもとに **成長指示** を表示する。
+
+---
+
+## 画面構成
+
+| 画面       | パス      | 説明                          |
+| ---------- | --------- | ----------------------------- |
+| マイページ | `/mypage` | ゆとシート設定 + 成長指示表示 |
+
+### ページ・コンポーネント構成
+
+```
+app/mypage/
+└── page.tsx                              # マイページ（"use client"）
+
+component/
+├── templates/
+│   └── MyPageTemplate.tsx                # マイページ全体レイアウト
+└── organisms/
+    └── mypage/
+        ├── RegulationSheetForm.tsx       # レギュレーションごとのゆとシートURL・備考編集
+        └── GrowthGuide.tsx               # 最新レギュレーションの成長指示表示
+```
+
+### 画面レイアウト（概念図）
+
+```
+┌──────────────────────────────────────────────┐
+│ ヘッダー（表示名 / ログアウト）              │
+├──────────────────────────────────────────────┤
+│ ■ ゆとシート設定                             │
+│   レギュレーション一覧（日程登録ありが対象）  │
+│   ┌──────────────────────────────────────┐  │
+│   │ 第N期  ゆとシートURL [____] 備考[__]  │  │
+│   │                              [保存]   │  │
+│   └──────────────────────────────────────┘  │
+│                                              │
+│ ■ 成長指示（最新レギュレーション）          │
+│   キャラクター名: XXXX                        │
+│   ゆとシートURL: [リンク（別タブ）]          │
+│   - 経験点 +1200 点                           │
+│   - 成長 3 回                                 │
+│   - 報酬金額 5000 G                           │
+│   - 名誉点 40 点                              │
+└──────────────────────────────────────────────┘
+```
+
+---
+
+## ゆとシート設定（URL・備考の登録）
+
+`RegulationSheetForm` で、各レギュレーションに対し本人の **ゆとシート URL** と **備考** を保存する。
+
+- 対象レギュレーション一覧 = 「`level_cap_schedule` が空配列でない（日程登録あり）」レギュレーション（後述「最新レギュレーション判定」と同じ条件で絞り込み、最新のものまで）。
+- 保存先 = `user_regulation_sheets`（[03_migration.md](./03_migration.md)）。`UNIQUE(user_id, regulation_id)` で upsert。
+- 保存は `/api/mypage`（PUT）経由（Service Role Key・本人スコープ）。フロントは秘密鍵を持たない。
+
+### 画面文言（MYPAGE）
+
+```typescript
+// const/pages/MYPAGE.tsx
+export const MYPAGE: {
+  TEXT: { [key: string]: string };
+  VALUE: { [key: string]: string | number };
+} = {
+  TEXT: {
+    TITLE: "マイページ",
+    SHEET_SECTION: "ゆとシート設定",
+    URL_LABEL: "ゆとシートURL",
+    CHARACTOR_ROLE_LABEL: "備考",
+    SAVE: "保存",
+    SAVED: "保存しました",
+    GUIDE_SECTION: "成長指示",
+    CHARACTER_NAME: "キャラクター名",
+    SHEET_LINK: "ゆとシートを開く",
+    GUIDE_EXP: "経験点",
+    GUIDE_GROWTH: "成長",
+    GUIDE_REWARD: "報酬金額",
+    GUIDE_HONOR: "名誉点",
+    GUIDE_NONE: "現在、成長指示はありません",
+    NO_LATEST: "対象のレギュレーションがありません",
+  },
+  VALUE: {
+    UNIT_EXP: "点",
+    UNIT_GROWTH: "回",
+    UNIT_REWARD: "G",
+    UNIT_HONOR: "点",
+    // JSONP 取得用のコールバッククエリ。コールバック名はサーバー固定の安全な定数（英数字のみ）。
+    // ユーザー入力は一切使わない（コールバック名インジェクション防止）。サーバー側で付与する。
+    YUTOSHEET_JSONP_QUERY: "&callback=ytsheetJsonp",
+  },
+} as const;
+```
+
+---
+
+## データ取得フロー（成長指示）
+
+成長指示は以下の順序で算出・表示する。
+
+```
+1. 最新レギュレーション判定
+   - regulation_items のうち level_cap_schedule が空配列でない（日程登録あり）もので最新（id 最大）を取得
+2. ゆとシートURL取得
+   - user_regulation_sheets から (本人 user_id, 最新 regulation_id) のレコードを取得
+   - URL 未登録なら成長指示は表示せず「ゆとシート設定」へ誘導
+3. ゆとシートJSON fetch
+   - URL に "&callback=ytsheetJsonp"（サーバー固定のコールバック名）を付与し、API Route /api/yutosheet 経由でサーバーサイド取得（CORS 回避・JSONP 形式）
+   - サーバーは取得した JSONP レスポンス本文からコールバックラッパーを文字列処理で除去し JSON.parse する（eval/Function/動的script は使わない）
+4. 現在のレベルキャップ解決
+   - 今日の日付が level_cap_schedule のどの level 区間に属するかを判定
+   - その belt_type + level の level_cap 行（min_exp / min_growth / min_reward / min_honor / exp_diff）を取得
+5. 成長指示計算
+   - ゆとシート JSON の expTotal / historyGrowTotal / historyMoneyTotal / historyHonorTotal と
+     level_cap のしきい値を比較して 4 条件を算出
+6. 表示
+   - キャラクター名 / ゆとシートURL（別タブ）/ 成長指示
+```
+
+### CORS・サーバーサイド取得方針（重要）
+
+ゆとシート JSON はブラウザから外部サイト（`https://yutorize.2-d.jp/...`）への直接 fetch になり、
+**CORS で失敗する可能性が高い**。したがって **API Route 経由のプロキシ取得を推奨・採用** する。
+
+```
+ブラウザ → /api/yutosheet?url=<ゆとシートURL> （同一オリジン）
+         → サーバーがゆとシートURL + "&callback=ytsheetJsonp" を fetch（JSONP 形式）
+         → サーバーが JSONP ラッパーを文字列処理で除去し JSON.parse（eval/Function/script 不使用）
+         → 必要フィールドだけを抽出して返却
+```
+
+- `/api/yutosheet` は GET。クエリ `url` を受け取り、許可ドメイン（`yutorize.2-d.jp`）のみ通す（SSRF 対策）。**URL 検証アルゴリズムは後述「## セキュリティ要件」を必ず参照**（保存時 `/api/mypage` PUT・表示時 href 設定・03_migration.md からも本ロジックを共有する）。
+- `&callback=ytsheetJsonp` はサーバー側で付与する（クエリの重複付与を避けるため URL を正規化）。コールバック名は**サーバー固定の安全な定数（英数字のみ）**であり、**ユーザー入力を一切使わない**（コールバック名インジェクション防止）。S-1 検証を通したあとにサーバー側でクエリを付与する。
+- サーバーは取得した JSONP レスポンス本文（`ytsheetJsonp({...JSON...})` または `ytsheetJsonp({...});` 形式）から、**`eval` / `Function` / `<script>` 実行を一切使わず**、コールバックラッパー（先頭の `ytsheetJsonp(` と末尾の `)` / `);`）を文字列処理で除去し、内側を `JSON.parse` する。
+- 取得失敗・パース失敗（想定したラッパー形式でない・`JSON.parse` 失敗）はいずれも 502 `{ error, code: "UPSTREAM_ERROR" }`。
+- レスポンスは外部 JSON 全体・生テキスト（生の JSONP 文字列を含む）を転送せず、後述「## セキュリティ要件」のホワイトリストフィールドのみ返却する。
+
+---
+
+## 最新レギュレーション判定ロジック
+
+「マイページ上での最新レギュレーション」は **`level_cap_schedule` の登録があるもの** を最新とする。
+ゆとシートの紐づけ対象も同条件で最新のものまでとする。
+
+```
+// 擬似コード（実装ではない）
+latest = regulation_items
+  .filter(r => Array.isArray(r.level_cap_schedule) && r.level_cap_schedule.length > 0)
+  .sort((a, b) => b.id - a.id)[0]   // id 最大を最新とする
+```
+
+> 既存 `getRegulationItems("latest")`（`const/function/getRegulationItems.ts`）は「id 最大」を最新としていたが、
+> 本機能ではこれを流用せず、**`level_cap_schedule` 非空** で絞り込んだ上で id 最大を採る
+> 専用関数 `getLatestScheduledRegulation` を新設する（既存関数の挙動を壊さないため）。
+
+---
+
+## 現在のレベルキャップ解決（区間判定）
+
+`level_cap_schedule` は `[{ "levelCapId": number, "level": string, "date": "YYYY-MM-DD" }]`。
+今日の日付がどの level の区間に属するかで対象 level を決定する。
+
+> 例: レベル5が 5/1、現在 5/10、レベル6が 6/1 の場合 → 「レベル5」の値を取得（= 現在日付が属する行の値）。
+
+```
+// 擬似コード（実装ではない）
+// 1. schedule を date 昇順にソート
+sorted = schedule.sort((a, b) => a.date <= b.date ? -1 : 1)
+today  = 現在日付（YYYY-MM-DD）
+
+// 2. 「date <= today」を満たす最後の要素が現在区間
+current = null
+for entry of sorted:
+  if entry.date <= today:
+    current = entry        // より新しい開始日で上書き
+  else:
+    break                  // ソート済みなので以降は未来
+
+// 3. current が null（最初の日程より前）の場合の扱い
+//    → 「まだレベルキャップ未開始」とみなし成長指示は表示しない（GUIDE_NONE）
+if current == null: 成長指示なし
+
+// 4. current.level と レギュレーションの belt_type（regulation_items.level_cap_belt）で
+//    level_cap 行を一意に特定（UNIQUE(belt_type, level)）
+levelCapRow = level_cap.find(belt_type == regulation.levelCapBelt && level == current.level)
+```
+
+> **belt_type の取得元**: レギュレーションの `level_cap_belt`（`'B'` / `'C'`）を使う。
+> `level_cap` は `UNIQUE(belt_type, level)` のため `belt_type` + `level` で一意。
+
+---
+
+## 成長指示の計算ロジック（Issue の 4 条件）
+
+最新レギュレーションのゆとシート JSON から取得した値と、現在のレベルキャップ行のしきい値を比較する。
+
+| 条件                             | 表示                                          |
+| -------------------------------- | --------------------------------------------- |
+| `expTotal < min_exp`             | 経験点「+（`exp_diff` の値）」点              |
+| `historyGrowTotal < min_growth`  | 成長「`min_growth - historyGrowTotal`」回     |
+| `historyMoneyTotal < min_reward` | 報酬金額「`min_reward - historyMoneyTotal`」G |
+| `historyHonorTotal < min_honor`  | 名誉点「`min_honor - historyHonorTotal`」点   |
+
+> **経験点だけ差が `exp_diff`（差分カラム）固定** な点に注意。他 3 つは「しきい値 − 現在値」の不足分。
+> ただし `exp_diff` は nullable（先頭レベルは「直前レベルとの差分」が定義できず null）。
+> **先頭レベルでは `exp_diff` が null のため経験点指示は出ない**（null は評価しない）。
+> `min_growth` / `min_honor` も nullable で、`null` の場合はその条件を **評価しない**（指示を出さない）。
+> `exp_diff` も `min_growth`/`min_honor` と同様に null 非評価とする。
+
+```typescript
+// 計算ロジック（型サンプル・擬似コード。実装コードではない）
+// 配置: const/function/calcGrowthGuide.ts
+
+type GrowthGuideInput = {
+  expTotal: number;
+  historyGrowTotal: number;
+  historyMoneyTotal: number;
+  historyHonorTotal: number;
+  minExp: number;
+  minGrowth: number | null;
+  minReward: number;
+  minHonor: number | null;
+  expDiff: number | null;
+};
+
+// 戻り値の型は GrowthGuideType（下記）
+// 各条件を満たすときのみ要素を push する想定:
+//   exp:    expDiff != null && expTotal < minExp    → { kind: "exp",    value: expDiff }
+//   growth: minGrowth != null && grow < minGrowth   → { kind: "growth", value: minGrowth - historyGrowTotal }
+//   reward: historyMoneyTotal < minReward           → { kind: "reward", value: minReward - historyMoneyTotal }
+//   honor:  minHonor != null && honor < minHonor    → { kind: "honor",  value: minHonor - historyHonorTotal }
+```
+
+---
+
+## ゆとシート JSON の取得方法・フィールド注記（重要・要確認）
+
+### 取得方法
+
+キャラクターシート URL に `&callback=<コールバック名>` を付与すると JSONP 形式（`<コールバック名>({...JSON...})`）で取得できる。
+本機能ではコールバック名を**サーバー固定の安全な定数 `ytsheetJsonp`（英数字のみ）**とし、**ユーザー入力を一切使わない**（コールバック名インジェクション防止）。
+
+```
+例: https://yutorize.2-d.jp/ytsheet/sw2.5/?id=XXX&callback=ytsheetJsonp
+レスポンス例: ytsheetJsonp({"characterName":"...", ...});
+```
+
+> サーバーは取得した JSONP レスポンスを **スクリプトとして実行せず**（`eval` / `Function` / 動的 `<script>` 禁止）、
+> コールバックラッパー（先頭の `ytsheetJsonp(` と末尾の `)` / `);`）を文字列処理で除去し、内側を `JSON.parse` する。
+> ラッパー形式でない・`JSON.parse` 失敗時は 502 `UPSTREAM_ERROR` 扱い（詳細は「## セキュリティ要件」S-2 / S-3）。
+
+### フィールドの確度
+
+| フィールド          | 用途           | 確度                             |
+| ------------------- | -------------- | -------------------------------- |
+| `characterName`     | キャラクター名 | **公式ドキュメントで確認済み**   |
+| `expTotal`          | 総経験点       | **未確認**（公式一覧に記載なし） |
+| `historyGrowTotal`  | 総成長回数     | **未確認**（公式一覧に記載なし） |
+| `historyMoneyTotal` | 総報酬額       | **未確認**（公式一覧に記載なし） |
+| `historyHonorTotal` | 総名誉点       | **未確認**（公式一覧に記載なし） |
+
+> **注記（必読）**: `expTotal` / `historyGrowTotal` / `historyMoneyTotal` / `historyHonorTotal` の 4 フィールドは
+> **公式ドキュメントの一覧に記載がなく、フィールド名・型・正確な意味が未確認**。
+> 本設計では **Issue 記載のフィールド名をそのまま使用** するが、**実 JSON レスポンスでフィールドの存在・型を要確認** とする。
+> これらは数値として扱う想定だが、**文字列（カンマ区切り等）の可能性** もあるため、
+> 取得時に必ず数値変換する設計とする（後述のパース方針）。
+
+### 型・パース方針（`any`/`unknown` 禁止に準拠）
+
+ゆとシート JSON は外部由来でスキーマが保証されないため、`any`/`unknown` を使わず
+`Record<string, string | number | boolean | null>` として受け、ランタイムチェック + 数値変換で取り込む。
+
+```typescript
+// const/type/mypage/YutosheetJsonType.ts
+// マイページで使用する確定後の型（数値化済み）
+export type YutosheetJsonType = {
+  characterName: string;
+  expTotal: number;
+  historyGrowTotal: number;
+  historyMoneyTotal: number;
+  historyHonorTotal: number;
+};
+```
+
+```typescript
+// 取り込み方針（擬似・/api/yutosheet 内で実施）
+// raw: Record<string, string | number | boolean | null>
+// 数値フィールドはカンマ・空白を除去してから Number() 変換。NaN は 0 とみなす（または成長指示対象外）。
+//
+// toNumber(v):
+//   if typeof v === "number" → v
+//   if typeof v === "string" → Number(v.replace(/[,\s]/g, "")) || 0
+//   else → 0
+//
+// characterName は文字列としてそのまま（存在しなければ空文字）。
+```
+
+> 数値が `0` 扱いになった場合、しきい値との比較で誤った指示を出す恐れがあるため、
+> **実 JSON 確認後にフィールド名・型を確定** し、必要なら「フィールド欠落時は成長指示を非表示」にフォールバックする方針へ調整する。
+
+---
+
+## ゆとシート URL の別タブ表示
+
+成長指示セクションのゆとシート URL は **別タブ遷移**（`target="_blank"` 相当 / `rel="noopener noreferrer"`）。
+表示は人間向けの元 URL（クエリ無しの元 URL のまま。`&callback=` 等の JSONP 用クエリは付けない）を用いる。
+
+> **XSS 注意**: href にユーザー入力 URL を設定するため、表示時にも後述「## セキュリティ要件」の URL 検証を通す。検証を通らない URL は **リンク化しない**（プレーンテキスト表示またはエラー）。`javascript:` / `data:` スキーム等の混入を防ぐ。
+
+---
+
+## 型定義サンプル（規約準拠の配置）
+
+```typescript
+// const/type/mypage/UserRegulationSheetType.ts
+export type UserRegulationSheetType = {
+  id: number;
+  userId: string;
+  regulationId: number;
+  yutosheetUrl: string;
+  note: string;
+  updatedAt: string | null;
+};
+```
+
+```typescript
+// const/type/mypage/GrowthGuideType.ts
+export type GrowthGuideKind = "exp" | "growth" | "reward" | "honor";
+
+export type GrowthGuideItemType = {
+  kind: GrowthGuideKind;
+  value: number;
+};
+
+export type GrowthGuideType = {
+  characterName: string;
+  sheetUrl: string;
+  items: GrowthGuideItemType[]; // 条件を満たした指示のみ
+};
+```
+
+```typescript
+// const/type/levelCap/LevelCapType.ts（既存に expDiff を追加）
+export type LevelCapItemType = {
+  // ...既存フィールド...
+  minExp: number;
+  minGrowth: number | null;
+  minReward: number;
+  minHonor: number | null;
+  expDiff: number | null; // 追加: 直前行の min_exp との差分。先頭行は差分が定義できないため null（[03_migration.md] 参照）
+  // ...
+};
+```
+
+---
+
+## DB 操作 / データ取得関数の責務一覧
+
+| 関数 / 配置                                      | 責務                                                                                                                                                     |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `const/function/getLatestScheduledRegulation.ts` | `level_cap_schedule` 非空のレギュレーションの最新（id 最大）を取得                                                                                       |
+| `const/function/getUserRegulationSheet.ts`       | `/api/mypage`(GET) 経由で本人のゆとシート設定を取得（snake→camel 変換）                                                                                  |
+| `const/function/resolveCurrentLevelCap.ts`       | 今日の日付が属する level 区間を判定し、`belt_type`+`level` から `level_cap` 行を取得（`Number()` で数値化）                                              |
+| `const/function/calcGrowthGuide.ts`              | ゆとシート値 + level_cap しきい値から成長指示を算出                                                                                                      |
+| `/api/mypage`(GET/PUT) route                     | 本人の `user_regulation_sheets` 取得・upsert（Service Role Key・本人スコープ）                                                                           |
+| `/api/yutosheet`(GET) route                      | ゆとシート JSONP のプロキシ取得（`&callback=ytsheetJsonp` 付与）・ラッパー除去 → `JSON.parse`（eval/Function/script 不使用）・数値化・必要フィールド抽出 |
+
+> 既存関数のパターンに準拠: snake_case → camelCase マッピング、数値は `Number()` 変換、エラーは `throw` し画面側は `useErrorHandler` で処理（`let ignore` 禁止）。
+
+---
+
+## セキュリティ要件
+
+> 本セクションは client マイページ機能のセキュリティ設計の **正本**。
+> 01_auth.md / 03_migration.md / 00_overview.md からは本セクションを参照する（詳細の重複記載を避ける）。
+> 以下の擬似コードはすべて **設計上のイメージであり実装コードではない**。実装時は規約（`any`/`unknown` 禁止・絶対パス `@/`・型は `number | null` 等で正確に）に準拠すること。
+
+### S-1. ゆとシート URL 検証（SSRF / XSS 共通ロジック）【最優先】
+
+`/api/yutosheet`（取得時）・`/api/mypage` PUT（保存時）・表示時（href 設定時）の **3 経路すべて** で同一の URL 検証関数を共有する（配置例: `const/function/validateYutosheetUrl.ts`）。検証を通らない URL は、保存時 400 / 表示時はリンク化しない / 取得時 400 とする。
+
+> **コールバッククエリ付与の順序**: `/api/yutosheet` では、まずユーザー入力 URL に対し本 S-1 検証を通し（不正なら 400）、**検証を通った URL に対してのみサーバー側で `&callback=ytsheetJsonp` を付与**する。コールバック名は固定の安全な定数（英数字のみ）であり、ユーザー入力を一切使わない（コールバック名インジェクション防止）。
+
+検証アルゴリズム（**完全一致のホスト判定が肝。`includes`/`startsWith`/`endsWith` は禁止**）:
+
+```
+// 擬似コード（実装コードではない）。戻り値の型イメージ: URL | null（不正なら null）
+// 配置: const/function/validateYutosheetUrl.ts
+
+const ALLOWED_HOST = "yutorize.2-d.jp";
+
+// 1. パース。失敗は不正（呼び出し側で 400 / リンク化しない）
+let url: URL;
+try {
+  url = new URL(input);
+} catch {
+  return null; // パース失敗 → 不正
+}
+
+// 2. スキームは https のみ許可（http も不可）
+if (url.protocol !== "https:") return null;
+//    → これにより javascript: / data: / file: / gopher: / ftp: 等は自動的に弾かれる
+
+// 3. ホストは小文字化したうえで「完全一致」のみ許可
+//    includes / startsWith / endsWith は使わない（部分一致のすり抜けを防ぐ）
+if (url.hostname.toLowerCase() !== ALLOWED_HOST) return null;
+
+// 4. userinfo（username / password）付き URL は拒否
+if (url.username !== "" || url.password !== "") return null;
+
+// 5. 非標準ポートは拒否（https 既定の 443 以外。url.port は既定時 "" になる）
+if (url.port !== "" && url.port !== "443") return null;
+
+return url; // 妥当
+```
+
+**完全一致が必須な理由（`includes`/`startsWith`/`endsWith` 禁止）と弾くべき危険例**:
+
+| 危険な入力例                                 | すり抜ける条件                                | 本ロジックでの判定                     |
+| -------------------------------------------- | --------------------------------------------- | -------------------------------------- |
+| `https://yutorize.2-d.jp.evil.com/`          | `startsWith("yutorize.2-d.jp")` だと通過      | ホスト完全一致でないため拒否           |
+| `https://evil.com/?x=yutorize.2-d.jp`        | `includes("yutorize.2-d.jp")` だと通過        | ホストは `evil.com` のため拒否         |
+| `https://evilyutorize.2-d.jp/`               | `endsWith` 系の甘い判定で通過                 | ホスト完全一致でないため拒否           |
+| `http://yutorize.2-d.jp@169.254.169.254/`    | userinfo 詐称（実ホストは `169.254.169.254`） | https でない＋userinfo付きで二重に拒否 |
+| `https://yutorize.2-d.jp@evil.com/`          | userinfo 詐称                                 | ホスト `evil.com`＋userinfo付きで拒否  |
+| `javascript:alert(1)` / `data:text/html,...` | スキーム検証なしだと XSS                      | protocol が https でないため拒否       |
+| `file:///etc/passwd` / `gopher://...`        | スキーム検証なしだと内部リソース読取          | protocol が https でないため拒否       |
+
+> `javascript:` / `data:` の排除は **保存時 XSS の温床（別タブリンクの href にユーザー入力 URL を使う）** を断つために必須。S-1 は保存時・表示時の双方で適用する。
+
+### S-2. プロキシ fetch の安全化（リダイレクト追跡禁止・内部IP拒否・リソース制限）【最優先】
+
+`/api/yutosheet` の外部 fetch は以下を満たす。
+
+- **リダイレクト追跡禁止**: fetch は `redirect: "manual"`。30x レスポンスはエラー（502 `UPSTREAM_ERROR`）扱いとし、追跡しない。
+  - 目的: リダイレクト経由での内部 IP 到達・DNS リバインディングを防ぐ。
+- **内部IP到達拒否**: 以下の帯域への到達を拒否する方針とする。IP リテラルの直接指定（ホスト名がドメインでなく IP）も拒否。
+  - IPv4: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `127.0.0.0/8`, `169.254.0.0/16`
+  - IPv6: `::1`（ループバック）, `fc00::/7`（ユニークローカル）
+  - S-1 でホストを `yutorize.2-d.jp` 完全一致に限定しているため一次的には到達しないが、DNS 解決結果が内部 IP を指す（リバインディング）ケースに備え多重防御として明記。
+- **リソース制限**:
+  - `AbortController` でタイムアウト（例: 5〜10 秒）。超過で中断し 502。
+  - 最大レスポンスサイズ上限（例: 1〜2MB）。ストリームを読みながら累積バイト数が上限超過した時点で中断し 502。
+  - メソッドは **GET 固定**。
+  - レスポンスの `Content-Type` は **JavaScript/JSON 系のみ許可**（`application/javascript` / `text/javascript` / `application/json`）。JSONP は JavaScript 系で返るため許可する。それ以外は 502。
+- **外部レスポンスをスクリプトとして実行しない**: JSONP 本文は `eval` / `Function` / 動的 `<script>` 注入で実行してはならない。コールバックラッパーを**文字列処理で除去**し、内側を `JSON.parse` する。これにより取得元が悪意あるコードを返しても実行されない（コールバック名はサーバー固定の英数字定数で、ユーザー入力を含めない）。
+
+```
+// 擬似コード（実装コードではない）
+const controller = new AbortController();
+const timer = setTimeout(() => controller.abort(), 8000); // 例: 8 秒
+const res = await fetch(normalizedUrl, {
+  method: "GET",
+  redirect: "manual",        // 30x は追跡しない
+  signal: controller.signal,
+});
+// res.status が 300〜399 → 502（リダイレクト拒否）
+// res.headers Content-Type が JavaScript/JSON 系でない（application/javascript・text/javascript・application/json 以外）→ 502
+// 本文読み取り中に累積バイト > MAX_BYTES → 中断して 502
+//
+// 取得した本文（JSONP）を eval/Function/動的script を一切使わずに処理する:
+//   1. コールバックラッパー除去: 先頭 "ytsheetJsonp(" と末尾 ")" / ");" を文字列処理で除去
+//   2. 内側を JSON.parse（失敗・ラッパー形式不一致 → 502 UPSTREAM_ERROR）
+```
+
+### S-3. プロキシ応答の最小化・エラー秘匿【Medium】
+
+- プロキシは JSONP ラッパー除去 → `JSON.parse` 後に、以下 **ホワイトリストフィールドのみ** を抽出して返却する（外部 JSON 全体・生テキスト・生の JSONP 文字列の転送は禁止）。
+  - `characterName` / `expTotal` / `historyGrowTotal` / `historyMoneyTotal` / `historyHonorTotal`
+  - 数値フィールドは前述「型・パース方針」に従い数値化する。
+- エラーレスポンスは共通の `{ error, code }` 形式に固定し、**upstream のステータス本文・スタックトレース・内部詳細を含めない**（`UPSTREAM_ERROR` / `BAD_REQUEST` 等の固定 code のみ）。
+
+### S-4. 入力検証【Medium】
+
+| 入力            | 検証                                                                                                                               |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `regulationId`  | 整数であること。さらに **対象レギュレーション集合（`level_cap_schedule` 登録あり）に属する**ことを確認（属さなければ 400 / 404）。 |
+| `yutosheet_url` | 最大長 **2048 字**（超過で 400）。加えて S-1 の URL 検証を通す。                                                                   |
+| `note`          | 最大長 **1000 字**（例。超過で 400）。                                                                                             |
+
+### S-5. 本人スコープ・認可（参照）
+
+`/api/mypage` の GET / PUT は **入力から user_id を受け取らず、セッション user_id のみ** で `.eq("user_id", sessionUserId)` する。role 判定はフェイルクローズの allowlist で行う。詳細は [01_auth.md](./01_auth.md)「## セキュリティ要件」を参照。
+
+---
+
+## 未確定・要確認事項
+
+- ゆとシート JSON の 4 数値フィールド（`expTotal` 等）の **存在・型（数値/カンマ区切り文字列）が未確認**。実レスポンス確認後に確定し、欠落時のフォールバック（成長指示非表示）を決める。
+- 現在日付が最初の日程より前のとき（レベルキャップ未開始）の表示方針（本設計では「成長指示なし」）。
+- ゆとシート URL 未登録レギュレーションの扱い（設定セクションへ誘導、成長指示は非表示）。
+- `&callback=ytsheetJsonp`（JSONP 用コールバッククエリ）の付与をサーバー側に一元化する前提（クエリ重複防止のため URL 正規化が必要）。コールバック名はサーバー固定の安全な定数（英数字のみ）でユーザー入力を含めない。
+- ゆとシート側が返す JSONP ラッパーの正確な形式（末尾が `)` か `);` か、関数名前後の空白有無など）は実レスポンスで要確認。ラッパー除去は eval/Function/script を使わず文字列処理で行い、形式不一致・`JSON.parse` 失敗は 502 `UPSTREAM_ERROR` 扱い。

--- a/docs/client/design/03_migration.md
+++ b/docs/client/design/03_migration.md
@@ -1,0 +1,243 @@
+# DB 変更 設計（マイグレーション）
+
+## 概要
+
+本 Issue では以下 2 つの DB 変更を行う。既存の番号体系（009 が最新）に続けて、`010_add_mypage.sql` の **1 ファイルに統合** して追加する（exp_diff 追加 + user_regulation_sheets 作成）。
+
+| マイグレーション | 内容 |
+|------------------|------|
+| `010_add_mypage.sql` | （1）`level_cap` に差分カラム `exp_diff` を追加し、既存行を再計算 UPDATE。（2）`user_regulation_sheets` テーブル新規作成 + RLS。exp_diff 追加 + user_regulation_sheets 作成 を 1 ファイルに統合 |
+
+> マイグレーションは必ず番号順・依存順で実行する。1 ファイル内では exp_diff → user_regulation_sheets の順で適用する。
+
+---
+
+## 010_add_mypage.sql（1）: level_cap への差分カラム追加
+
+### 目的
+
+成長指示の経験点条件（`expTotal < min_exp` のとき「経験点 +（差分）点」）で使用する、
+**直前レベルの `min_exp` との差分** をカラムとして保持する。
+
+### カラム設計
+
+| 項目 | 値 | 根拠 |
+|------|-----|------|
+| カラム名（DB） | `exp_diff` | 既存カラムの snake_case 命名（`min_exp` 等）に合わせる。「経験点差分」を表す簡潔名 |
+| 型側（TS） | `expDiff: number \| null` | 既存 `LevelCapItemType` の camelCase 命名に合わせる。先頭行は NULL のため nullable（既存 nullable フィールド `minGrowth`/`minHonor` と同パターン） |
+| 型 | `integer`（nullable・DEFAULT なし） | `min_exp` が integer のため差分も integer。先頭行は「直前レベルとの差分」が定義できないため NULL とする。既存行は UPDATE で再計算 |
+
+### 差分の定義
+
+同一 `belt_type` 内で `sort_order` 昇順に並べたときの「**直前の行の `min_exp` との差**」。
+
+```
+exp_diff(row) = row.min_exp - prev.min_exp   （prev = 同 belt_type で sort_order が 1 つ前の行）
+```
+
+### 先頭行の扱い（要確定事項 → 本設計の確定方針）
+
+各 `belt_type` の先頭行（`sort_order` 最小）は「直前の行」が存在しない。
+**選択肢**:
+
+| 案 | 先頭行の exp_diff | 長所 | 短所 |
+|----|-------------------|------|------|
+| A | `min_exp` 自身（前 = 0 とみなす） | 「0 からの差分」として一貫。経験点指示が必ず正の値になる | 先頭レベルで「+（min_exp 全額）」と大きな値が出る |
+| B | `0` | 先頭は差分なしを明示 | `expTotal < min_exp` 成立時に「+0 点」となり指示として無意味 |
+| C | `NULL` | 「未定義」を明示 | 型が `number` 必須から外れ、計算側で null 分岐が必要 |
+
+> **本設計の確定方針: 案 C（先頭行 = `NULL`）** を採用する。
+> 理由: `exp_diff` は「直前レベルとの差分」であり、先頭レベル（直前レベルが存在しない）には
+> 差分そのものが **定義できない**。0 や min_exp 自身で埋めるのは意味的に不正確なため、
+> 「未定義」を明示する NULL とし、**計算側で評価しない（経験点の成長指示を出さない）** のが意味的に正しい。
+> これは既存 nullable フィールド `min_growth`/`min_honor` が NULL のとき評価しないのと同じ扱い。
+> カラムは `integer`（nullable・DEFAULT なし）とし、UPDATE では LAG が先頭で NULL を返すことで先頭行が自然に NULL になる。
+
+### マイグレーション内容（擬似 SQL・実装ファイルは作成しない）
+
+```
+-- 010_add_mypage.sql（1）（設計上の擬似 SQL）
+
+-- 1. カラム追加（nullable・DEFAULT なし）
+ALTER TABLE level_cap
+  ADD COLUMN IF NOT EXISTS exp_diff integer;
+
+-- 2. 既存行の再計算（belt_type ごと sort_order 昇順の直前行との差）
+--    先頭行は直前行が存在しないため NULL（案 C）。
+--    ウィンドウ関数 LAG を用いる想定。LAG は先頭で NULL を返すので差も NULL になる:
+--      diff = min_exp - LAG(min_exp) OVER (PARTITION BY belt_type ORDER BY sort_order)
+--    （COALESCE を付けないことで先頭行が NULL のまま残る）
+UPDATE level_cap AS lc
+SET exp_diff = sub.diff
+FROM (
+  SELECT id,
+         min_exp - LAG(min_exp) OVER (PARTITION BY belt_type ORDER BY sort_order)
+           AS diff
+  FROM level_cap
+) AS sub
+WHERE lc.id = sub.id;
+```
+
+### 既存データでの計算結果（参考・migration 008 の値より）
+
+belt_type = `'B'`（sort_order 昇順）。先頭は案 C で NULL。
+
+| level | sort_order | min_exp | 直前 min_exp | exp_diff |
+|-------|-----------|---------|--------------|----------|
+| 2 | 1 | 3000 | (なし) | NULL |
+| 3 | 2 | 7000 | 3000 | 4000 |
+| 4 | 3 | 11000 | 7000 | 4000 |
+| 5 | 4 | 17000 | 11000 | 6000 |
+| 6 | 5 | 25000 | 17000 | 8000 |
+| 7 | 6 | 33500 | 25000 | 8500 |
+| 8 | 7 | 43500 | 33500 | 10000 |
+| 9 | 8 | 55500 | 43500 | 12000 |
+| 10 | 9 | 67500 | 55500 | 12000 |
+| 11/12① | 10 | 80000 | 67500 | 12500 |
+| 11/12② | 11 | 92000 | 80000 | 12000 |
+
+belt_type = `'C'`（sort_order 昇順）。先頭は案 C で NULL。
+
+| level | sort_order | min_exp | 直前 min_exp | exp_diff |
+|-------|-----------|---------|--------------|----------|
+| 5 | 1 | 17000 | (なし) | NULL |
+| 6 | 2 | 25000 | 17000 | 8000 |
+| 7 | 3 | 33500 | 25000 | 8500 |
+| 8 | 4 | 43500 | 33500 | 10000 |
+| 9 | 5 | 55500 | 43500 | 12000 |
+| 10 | 6 | 67500 | 55500 | 12000 |
+| 11 | 7 | 80000 | 67500 | 12500 |
+| 12 | 8 | 92000 | 80000 | 12000 |
+| 13 | 9 | 112000 | 92000 | 20000 |
+
+> belt `'C'` 先頭（Lv.5）は案 C で NULL。先頭レベルには「直前レベルとの差分」が定義できないため、計算側で評価せず経験点の成長指示を出さない。
+
+### 型・取得関数への影響
+
+- `application/frontend/client/const/type/levelCap/LevelCapType.ts` に `expDiff: number | null;` を追加（先頭行は NULL のため nullable。既存 nullable フィールド `minGrowth`/`minHonor` と同パターン）。
+- `const/function/getLevelCapItems.ts` の map に `expDiff: row.exp_diff !== null ? Number(row.exp_diff) : null,` を追加（既存の nullable フィールド `minGrowth`/`minHonor` と同じパターンに準拠）。
+- **成長指示の経験点条件への注意**: 先頭レベルでは `exp_diff` が null のため、`expTotal < min_exp` でも経験点の成長指示は **表示しない**（null は評価しない）。これは `min_growth`/`min_honor` が null のとき評価しないのと同じ扱い。
+- admin 側で `level_cap` を編集する場合は `exp_diff` を **自動再計算** する（手入力させない）方針が望ましい（min_exp 変更時に整合が崩れるため）。本 Issue のスコープ外だが、要確認事項として記載。
+
+---
+
+## 010_add_mypage.sql（2）: user_regulation_sheets テーブル新規作成
+
+### 目的
+
+ユーザーがレギュレーションごとに自分の **ゆとシート URL** と **備考** を保存する。
+
+### テーブル定義
+
+| カラム | 型 | 説明 |
+|--------|-----|------|
+| `id` | `serial` / `bigint generated always as identity` PK | 主キー |
+| `user_id` | `uuid NOT NULL`（FK → `auth.users(id)` ON DELETE CASCADE） | 所有ユーザー |
+| `regulation_id` | `integer NOT NULL`（FK → `regulation_items(id)` ON DELETE CASCADE） | 対象レギュレーション |
+| `yutosheet_url` | `text NOT NULL DEFAULT ''` | ゆとシート（キャラクターシート）URL。**保存時に API 層で URL 検証（https + `yutorize.2-d.jp` 完全一致・最大 2048 字）**。DB は長文を防ぐ最小限の制約のみで、内容検証はアプリ層が責務（[02_mypage.md](./02_mypage.md) S-1/S-4） |
+| `note` | `text NOT NULL DEFAULT ''` | 備考 |
+| `updated_by` | `uuid`（nullable, FK → `auth.users(id)`） | 最終更新者（admin の監査カラム方針に合わせる。本人更新のため通常 user_id と一致） |
+| `updated_at` | `timestamptz NOT NULL DEFAULT now()` | 最終更新日時 |
+| 制約 | `UNIQUE(user_id, regulation_id)` | 1 ユーザー × 1 レギュレーションで 1 レコード（upsert キー） |
+
+> **命名根拠**: テーブル名は「ユーザー × レギュレーション の シート設定」を表す `user_regulation_sheets`（複数形・snake_case、既存テーブル `regulation_items` 等の命名に整合）。
+> カラム名はゆとシートのドメイン語に合わせ `yutosheet_url`。`updated_by`/`updated_at` は admin の共通監査カラム方針を踏襲（本人更新のため `updated_by` は基本的に `user_id` と同値だが、将来の管理者代理更新に備えて保持）。
+
+### マイグレーション内容（擬似 SQL・実装ファイルは作成しない）
+
+```
+-- 010_add_mypage.sql（2）（設計上の擬似 SQL）
+
+CREATE TABLE user_regulation_sheets (
+  id             bigint generated always as identity PRIMARY KEY,
+  user_id        uuid    NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  regulation_id  integer NOT NULL REFERENCES regulation_items(id) ON DELETE CASCADE,
+  yutosheet_url  text    NOT NULL DEFAULT '',
+  note           text    NOT NULL DEFAULT '',
+  updated_by     uuid    REFERENCES auth.users(id),
+  updated_at     timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, regulation_id)
+);
+
+-- 検索用インデックス（本人の全レコード取得が多いため）
+CREATE INDEX idx_user_regulation_sheets_user ON user_regulation_sheets(user_id);
+
+ALTER TABLE user_regulation_sheets ENABLE ROW LEVEL SECURITY;
+```
+
+### RLS ポリシー（本人のみ参照/編集可）
+
+`auth.uid() = user_id` の本人に限定する。
+
+```
+-- SELECT: 本人のみ
+CREATE POLICY "urs_select_own" ON user_regulation_sheets
+  FOR SELECT USING (auth.uid() = user_id);
+
+-- INSERT: 本人のみ（user_id = 自分）
+CREATE POLICY "urs_insert_own" ON user_regulation_sheets
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+-- UPDATE: 本人のみ
+CREATE POLICY "urs_update_own" ON user_regulation_sheets
+  FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+```
+
+> **書き込み経路**: 実際の保存は API Route `/api/mypage`(PUT)（Service Role Key）経由で行い、
+> Route 内で **セッションの user_id のみ** を対象に upsert する（リクエストボディの user_id は信用しない）。
+> RLS は多重防御（Service Role Key は RLS をバイパスするため、API 層での本人スコープ確定が一次防御）。
+> DELETE は本 Issue のスコープ外（URL を空文字に更新する運用）。必要になれば `urs_delete_own` を追加する。
+
+> **保存時の入力検証（必須）**: upsert 前に API 層で次を検証する（詳細は [02_mypage.md](./02_mypage.md)「## セキュリティ要件」を正本とする）。
+> - `yutosheet_url`: 最大長 **2048 字** + S-1 の URL 検証（**https かつ `yutorize.2-d.jp` 完全一致**。`javascript:`/`data:` 等は排除）。不正は **400**。空文字（未登録）は許可。
+> - `note`: 最大長 **1000 字**（例）。超過は 400。
+> - `regulation_id`: 整数 + 対象レギュレーション集合（`level_cap_schedule` 登録あり）に属することを確認。
+> - `user_id` / `updated_by`: **セッション由来でのみセット**し、リクエストボディ指定は無視。
+
+### upsert 仕様
+
+```
+-- /api/mypage PUT の処理（擬似）
+-- body: { regulationId: number, yutosheetUrl: string, note: string }
+-- user_id はセッションから取得
+INSERT INTO user_regulation_sheets (user_id, regulation_id, yutosheet_url, note, updated_by, updated_at)
+VALUES (:sessionUserId, :regulationId, :yutosheetUrl, :note, :sessionUserId, now())
+ON CONFLICT (user_id, regulation_id)
+DO UPDATE SET yutosheet_url = EXCLUDED.yutosheet_url,
+              note          = EXCLUDED.note,
+              updated_by    = EXCLUDED.updated_by,
+              updated_at    = now();
+```
+
+### 型定義
+
+```typescript
+// const/type/mypage/UserRegulationSheetType.ts
+export type UserRegulationSheetType = {
+  id: number;
+  userId: string;
+  regulationId: number;
+  yutosheetUrl: string;
+  note: string;
+  updatedAt: string | null;
+};
+```
+
+---
+
+## マイグレーション実行順序（再掲）
+
+```
+... 009_add_regulation_schedule.sql       → 既存（最新）
+010_add_mypage.sql                        → （1）ALTER + UPDATE（exp_diff） → （2）CREATE TABLE + RLS（user_regulation_sheets）を 1 ファイルに統合
+seed.sql                                   → 既存（必要ならテストユーザーのシート初期データを追記）
+```
+
+---
+
+## 未確定・要確認事項
+
+- **差分カラム先頭行の扱い**: **NULL に確定（案 C）**。先頭レベルには「直前レベルとの差分」が定義できないため NULL とし、計算側で評価しない（経験点の成長指示を出さない）。`min_growth`/`min_honor` の null 非評価と同じ扱い。
+- admin の `level_cap` 編集時に `exp_diff` を自動再計算するか（本 Issue スコープ外だが整合維持に必要）。
+- `user_regulation_sheets` の DELETE ポリシー要否（現状は URL 空更新で代替）。
+- `updated_by` を持つか（admin 監査方針に合わせ保持としたが、本人更新のみなら冗長との判断もあり得る）。

--- a/supabase/migrations/010_add_mypage.sql
+++ b/supabase/migrations/010_add_mypage.sql
@@ -1,0 +1,66 @@
+-- ============================================================
+-- 010_add_mypage.sql
+-- マイページ機能（client）の DB 変更をまとめて適用する。
+--   1. level_cap に exp_diff（直前レベルの min_exp との差分）を追加
+--   2. user_regulation_sheets（ユーザー別ゆとシート設定）を新規作成 + RLS
+-- ============================================================
+
+-- ============================================================
+-- 1. level_cap への差分カラム追加
+--    目的: 成長指示の経験点条件で使用する「直前レベルの min_exp との差分」を
+--          カラム exp_diff として保持する。
+--          各 belt_type の先頭行（sort_order 最小）は直前レベルが無いため NULL（案 C）。
+-- ============================================================
+ALTER TABLE level_cap
+  ADD COLUMN IF NOT EXISTS exp_diff integer;
+
+-- 既存行の再計算
+--   belt_type ごと sort_order 昇順の直前行との差を算出。
+--   LAG は先頭行で NULL を返すため、COALESCE を付けず先頭行は NULL のまま残す（案 C）。
+UPDATE level_cap AS lc
+SET exp_diff = sub.diff
+FROM (
+  SELECT id,
+         min_exp - LAG(min_exp) OVER (PARTITION BY belt_type ORDER BY sort_order)
+           AS diff
+  FROM level_cap
+) AS sub
+WHERE lc.id = sub.id;
+
+-- ============================================================
+-- 2. user_regulation_sheets テーブル作成
+--    目的: ユーザーがレギュレーションごとに自分のゆとシート URL と備考を保存する。
+--          1 ユーザー × 1 レギュレーションで 1 レコード（UNIQUE で upsert キー）。
+--          RLS で本人（auth.uid() = user_id）のみ参照/編集可とする。
+-- ============================================================
+CREATE TABLE user_regulation_sheets (
+  id             bigint generated always as identity PRIMARY KEY,
+  user_id        uuid    NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  regulation_id  integer NOT NULL REFERENCES regulation_items(id) ON DELETE CASCADE,
+  yutosheet_url  text    NOT NULL DEFAULT '',
+  note           text    NOT NULL DEFAULT '',
+  updated_by     uuid    REFERENCES auth.users(id),
+  updated_at     timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, regulation_id)
+);
+
+-- 検索用インデックス（本人の全レコード取得が多いため）
+CREATE INDEX idx_user_regulation_sheets_user ON user_regulation_sheets(user_id);
+
+ALTER TABLE user_regulation_sheets ENABLE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- RLS ポリシー（本人のみ参照/編集可）
+--   DELETE は本 Issue のスコープ外（URL 空更新で代替）。
+-- ============================================================
+-- SELECT: 本人のみ
+CREATE POLICY "urs_select_own" ON user_regulation_sheets
+  FOR SELECT USING (auth.uid() = user_id);
+
+-- INSERT: 本人のみ（user_id = 自分）
+CREATE POLICY "urs_insert_own" ON user_regulation_sheets
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+-- UPDATE: 本人のみ
+CREATE POLICY "urs_update_own" ON user_regulation_sheets
+  FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- ログインページ／フォーム・認証 API・middleware による認証フローを実装
- マイページ（育成ガイド表示・レギュレーションシート登録）を追加
- Supabase を `@supabase/ssr` クライアントへ移行し、admin クライアントを追加
- ユウトシート URL バリデーションと成長ガイド算出ロジック、マイページ用マイグレーションを追加

## Issue
Close #45

## Test plan
- ログイン・ログアウトが正常に動作すること
- 未認証時に middleware で `/login` へリダイレクトされること
- マイページでレギュレーションシート URL を登録・更新できること
- 育成ガイドが現在のレベルキャップに応じて表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)