### PR TITLE
E-63 proxy をルートガード分割（guard chain 化）

### DIFF
--- a/application/frontend/admin/lib/proxy/context.ts
+++ b/application/frontend/admin/lib/proxy/context.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { createSupabaseProxyClient } from "@/lib/proxy/supabaseProxyClient";
+import type { ProxyContext } from "@/lib/proxy/guards/types";
+
+// proxy の各ガードが参照する共通コンテキストを構築する。
+export async function buildProxyContext(
+  request: NextRequest
+): Promise<ProxyContext> {
+  const response = NextResponse.next();
+  const pathname = request.nextUrl.pathname;
+  const isApiRoute = pathname.startsWith("/api/");
+  const supabase = createSupabaseProxyClient(request, response);
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  return { request, response, pathname, isApiRoute, supabase, user };
+}

--- a/application/frontend/admin/lib/proxy/guards/adminRoleGuard.ts
+++ b/application/frontend/admin/lib/proxy/guards/adminRoleGuard.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import type { Guard } from "@/lib/proxy/guards/types";
+import { fetchUserRole } from "@/lib/proxy/role";
+
+const HOME_PATH = "/";
+
+// authPublicGuard 通過後（認証済み かつ 非公開パス）のみ実質評価。
+// admin 以外: API は 403、それ以外は "/"（ただし既に "/" なら許可）。
+export const adminRoleGuard: Guard = async (ctx) => {
+  if (!ctx.user) {
+    return null; // 未認証は authPublicGuard が処理済み（公開パスのみ到達）
+  }
+  const role = await fetchUserRole(ctx);
+  if (role !== "admin") {
+    if (ctx.isApiRoute) {
+      return NextResponse.json(
+        { error: "権限がありません", code: "FORBIDDEN" },
+        { status: 403 }
+      );
+    }
+    if (ctx.pathname !== HOME_PATH) {
+      return NextResponse.redirect(new URL(HOME_PATH, ctx.request.url));
+    }
+  }
+  return null;
+};

--- a/application/frontend/admin/lib/proxy/guards/authPublicGuard.ts
+++ b/application/frontend/admin/lib/proxy/guards/authPublicGuard.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import type { Guard } from "@/lib/proxy/guards/types";
+import { isPublicPath } from "@/lib/proxy/publicPaths";
+
+const LOGIN_PATH = "/login";
+const HOME_PATH = "/";
+
+// 未認証: 公開パスは許可、API は 401、それ以外は /login。
+// 認証済み かつ 公開パス: "/" へリダイレクト。
+export const authPublicGuard: Guard = (ctx) => {
+  const isPublic = isPublicPath(ctx.pathname);
+  if (!ctx.user) {
+    if (isPublic) {
+      return null;
+    }
+    if (ctx.isApiRoute) {
+      return NextResponse.json(
+        { error: "認証が必要です", code: "UNAUTHORIZED" },
+        { status: 401 }
+      );
+    }
+    return NextResponse.redirect(new URL(LOGIN_PATH, ctx.request.url));
+  }
+  if (isPublic) {
+    return NextResponse.redirect(new URL(HOME_PATH, ctx.request.url));
+  }
+  return null;
+};

--- a/application/frontend/admin/lib/proxy/guards/types.ts
+++ b/application/frontend/admin/lib/proxy/guards/types.ts
@@ -1,0 +1,17 @@
+import type { NextRequest, NextResponse } from "next/server";
+import type { SupabaseClient, User } from "@supabase/supabase-js";
+
+// proxy（旧 middleware）の各ガード間で共有するコンテキスト。
+export type ProxyContext = {
+  request: NextRequest;
+  response: NextResponse;
+  pathname: string;
+  isApiRoute: boolean;
+  supabase: SupabaseClient;
+  user: User | null;
+};
+
+// null を返したら次のガードへ。NextResponse を返したらそこで応答確定。
+export type Guard = (
+  ctx: ProxyContext
+) => Promise<NextResponse | null> | NextResponse | null;

--- a/application/frontend/admin/lib/proxy/publicPaths.ts
+++ b/application/frontend/admin/lib/proxy/publicPaths.ts
@@ -1,0 +1,8 @@
+// 認証不要の公開パス。
+const PUBLIC_PATHS = ["/login", "/signin", "/reset-password", "/api/auth"];
+
+export function isPublicPath(pathname: string): boolean {
+  return PUBLIC_PATHS.some(
+    (p) => pathname === p || pathname.startsWith(p + "/")
+  );
+}

--- a/application/frontend/admin/lib/proxy/role.ts
+++ b/application/frontend/admin/lib/proxy/role.ts
@@ -1,0 +1,12 @@
+import type { ProxyContext } from "@/lib/proxy/guards/types";
+
+// user_meta から role を取得。未取得時は "common" 扱い。
+export async function fetchUserRole(ctx: ProxyContext): Promise<string> {
+  if (!ctx.user) return "common";
+  const { data } = await ctx.supabase
+    .from("user_meta")
+    .select("role")
+    .eq("id", ctx.user.id)
+    .single<{ role: string | null }>();
+  return data?.role ?? "common";
+}

--- a/application/frontend/admin/lib/proxy/routeGuards.ts
+++ b/application/frontend/admin/lib/proxy/routeGuards.ts
@@ -1,0 +1,9 @@
+import type { Guard } from "@/lib/proxy/guards/types";
+import { authPublicGuard } from "@/lib/proxy/guards/authPublicGuard";
+import { adminRoleGuard } from "@/lib/proxy/guards/adminRoleGuard";
+
+// admin は全パスを matcher 対象とするため、共通のガード列を返す。
+// 公開パス判定は各ガード内で行う。
+export function resolveGuards(_pathname: string): Guard[] {
+  return [authPublicGuard, adminRoleGuard];
+}

--- a/application/frontend/admin/lib/proxy/supabaseProxyClient.ts
+++ b/application/frontend/admin/lib/proxy/supabaseProxyClient.ts
@@ -1,0 +1,25 @@
+import type { NextRequest, NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// anon key 経由の supabase server client を request/response の cookie に紐付けて生成する。
+// Service Role Key は使用しない。
+export function createSupabaseProxyClient(
+  request: NextRequest,
+  response: NextResponse
+): SupabaseClient {
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll: () => request.cookies.getAll(),
+        setAll: (cookiesToSet) => {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            response.cookies.set(name, value, options);
+          });
+        },
+      },
+    }
+  );
+}

--- a/application/frontend/admin/proxy.ts
+++ b/application/frontend/admin/proxy.ts
@@ -1,63 +1,16 @@
-import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { createServerClient } from "@supabase/ssr";
+import { buildProxyContext } from "@/lib/proxy/context";
+import { resolveGuards } from "@/lib/proxy/routeGuards";
 
 export async function proxy(request: NextRequest) {
-  const response = NextResponse.next();
-  const pathname = request.nextUrl.pathname;
-  const publicPaths = ["/login", "/signin", "/reset-password", "/api/auth"];
-  const isPublicPath = publicPaths.some((p) => pathname === p || pathname.startsWith(p + "/"));
-  const isApiRoute = pathname.startsWith("/api/");
-
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll: () => request.cookies.getAll(),
-        setAll: (cookiesToSet) => {
-          cookiesToSet.forEach(({ name, value, options }) => {
-            response.cookies.set(name, value, options);
-          });
-        },
-      },
-    }
-  );
-
-  const { data: { user } } = await supabase.auth.getUser();
-
-  if (!user) {
-    if (isPublicPath) {
-      return response;
-    }
-    if (isApiRoute) {
-      return NextResponse.json({ error: "認証が必要です", code: "UNAUTHORIZED" }, { status: 401 });
-    }
-    return NextResponse.redirect(new URL("/login", request.url));
-  }
-
-  if (isPublicPath) {
-    return NextResponse.redirect(new URL("/", request.url));
-  }
-
-  const { data: userMeta } = await supabase
-    .from("user_meta")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  const role = userMeta?.role ?? "common";
-
-  if (role !== "admin") {
-    if (isApiRoute) {
-      return NextResponse.json({ error: "権限がありません", code: "FORBIDDEN" }, { status: 403 });
-    }
-    if (pathname !== "/") {
-      return NextResponse.redirect(new URL("/", request.url));
+  const ctx = await buildProxyContext(request);
+  for (const guard of resolveGuards(ctx.pathname)) {
+    const result = await guard(ctx);
+    if (result) {
+      return result;
     }
   }
-
-  return response;
+  return ctx.response;
 }
 
 export const config = {

--- a/application/frontend/client/lib/proxy/context.ts
+++ b/application/frontend/client/lib/proxy/context.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { createSupabaseProxyClient } from "@/lib/proxy/supabaseProxyClient";
+import type { ProxyContext } from "@/lib/proxy/guards/types";
+
+// proxy の各ガードが参照する共通コンテキストを構築する。
+export async function buildProxyContext(
+  request: NextRequest
+): Promise<ProxyContext> {
+  const response = NextResponse.next();
+  const pathname = request.nextUrl.pathname;
+  const isApiRoute = pathname.startsWith("/api/");
+  const supabase = createSupabaseProxyClient(request, response);
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  return { request, response, pathname, isApiRoute, supabase, user };
+}

--- a/application/frontend/client/lib/proxy/guards/authGuard.ts
+++ b/application/frontend/client/lib/proxy/guards/authGuard.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import type { Guard } from "@/lib/proxy/guards/types";
+
+const LOGIN_PATH = "/login";
+
+// 未認証なら API は 401、それ以外は /login へリダイレクト。
+export const authGuard: Guard = (ctx) => {
+  if (!ctx.user) {
+    if (ctx.isApiRoute) {
+      return NextResponse.json(
+        { error: "認証が必要です", code: "UNAUTHORIZED" },
+        { status: 401 }
+      );
+    }
+    return NextResponse.redirect(new URL(LOGIN_PATH, ctx.request.url));
+  }
+  return null;
+};

--- a/application/frontend/client/lib/proxy/guards/loginRedirectGuard.ts
+++ b/application/frontend/client/lib/proxy/guards/loginRedirectGuard.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import type { Guard } from "@/lib/proxy/guards/types";
+import type { UserRoleType } from "@/const/type/auth/UserRoleType";
+import { fetchUserRole } from "@/lib/proxy/role";
+
+const MYPAGE_PATH = "/mypage";
+const ALLOWED_ROLES: readonly UserRoleType[] = ["general", "admin"];
+
+// /login にセッションあり かつ 許可ロール → /mypage。未認証・許可外はそのまま表示。
+export const loginRedirectGuard: Guard = async (ctx) => {
+  if (!ctx.user) return null;
+  const role = await fetchUserRole(ctx);
+  const allowed =
+    typeof role === "string" &&
+    (ALLOWED_ROLES as readonly string[]).includes(role);
+  if (allowed) {
+    return NextResponse.redirect(new URL(MYPAGE_PATH, ctx.request.url));
+  }
+  return null;
+};

--- a/application/frontend/client/lib/proxy/guards/roleGuard.ts
+++ b/application/frontend/client/lib/proxy/guards/roleGuard.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import type { Guard } from "@/lib/proxy/guards/types";
+import type { UserRoleType } from "@/const/type/auth/UserRoleType";
+import { fetchUserRole } from "@/lib/proxy/role";
+
+const LOGIN_PATH = "/login";
+
+// allowlist（フェイルクローズ）でロールを検証。許可外は API 403 / それ以外 /login。
+export const roleGuard =
+  (allowedRoles: readonly UserRoleType[]): Guard =>
+  async (ctx) => {
+    const role = await fetchUserRole(ctx);
+    const allowed =
+      typeof role === "string" &&
+      (allowedRoles as readonly string[]).includes(role);
+    if (!allowed) {
+      if (ctx.isApiRoute) {
+        return NextResponse.json(
+          { error: "権限がありません", code: "FORBIDDEN" },
+          { status: 403 }
+        );
+      }
+      return NextResponse.redirect(new URL(LOGIN_PATH, ctx.request.url));
+    }
+    return null;
+  };

--- a/application/frontend/client/lib/proxy/guards/types.ts
+++ b/application/frontend/client/lib/proxy/guards/types.ts
@@ -1,0 +1,17 @@
+import type { NextRequest, NextResponse } from "next/server";
+import type { SupabaseClient, User } from "@supabase/supabase-js";
+
+// proxy（旧 middleware）の各ガード間で共有するコンテキスト。
+export type ProxyContext = {
+  request: NextRequest;
+  response: NextResponse;
+  pathname: string;
+  isApiRoute: boolean;
+  supabase: SupabaseClient;
+  user: User | null;
+};
+
+// null を返したら次のガードへ。NextResponse を返したらそこで応答確定。
+export type Guard = (
+  ctx: ProxyContext
+) => Promise<NextResponse | null> | NextResponse | null;

--- a/application/frontend/client/lib/proxy/role.ts
+++ b/application/frontend/client/lib/proxy/role.ts
@@ -1,0 +1,17 @@
+import type { ProxyContext } from "@/lib/proxy/guards/types";
+
+// user_meta から role を取得（anon key・本人 RLS）。
+// 取得失敗・例外も含めフェイルクローズで評価するため、文字列または null に正規化する。
+export async function fetchUserRole(ctx: ProxyContext): Promise<string | null> {
+  if (!ctx.user) return null;
+  try {
+    const { data } = await ctx.supabase
+      .from("user_meta")
+      .select("role")
+      .eq("id", ctx.user.id)
+      .single<{ role: string | null }>();
+    return data?.role ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/application/frontend/client/lib/proxy/routeGuards.ts
+++ b/application/frontend/client/lib/proxy/routeGuards.ts
@@ -1,0 +1,17 @@
+import type { Guard } from "@/lib/proxy/guards/types";
+import type { UserRoleType } from "@/const/type/auth/UserRoleType";
+import { authGuard } from "@/lib/proxy/guards/authGuard";
+import { roleGuard } from "@/lib/proxy/guards/roleGuard";
+import { loginRedirectGuard } from "@/lib/proxy/guards/loginRedirectGuard";
+
+const LOGIN_PATH = "/login";
+// マイページ機能の認可は user_meta.role の allowlist（フェイルクローズ）。
+const MYPAGE_ALLOWED_ROLES: readonly UserRoleType[] = ["general", "admin"];
+
+// パスに応じて適用するガード列を返す。config.matcher と対応させること。
+export function resolveGuards(pathname: string): Guard[] {
+  if (pathname === LOGIN_PATH) {
+    return [loginRedirectGuard];
+  }
+  return [authGuard, roleGuard(MYPAGE_ALLOWED_ROLES)];
+}

--- a/application/frontend/client/lib/proxy/supabaseProxyClient.ts
+++ b/application/frontend/client/lib/proxy/supabaseProxyClient.ts
@@ -1,0 +1,25 @@
+import type { NextRequest, NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// anon key 経由の supabase server client を request/response の cookie に紐付けて生成する。
+// Service Role Key は使用しない。
+export function createSupabaseProxyClient(
+  request: NextRequest,
+  response: NextResponse
+): SupabaseClient {
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll: () => request.cookies.getAll(),
+        setAll: (cookiesToSet) => {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            response.cookies.set(name, value, options);
+          });
+        },
+      },
+    }
+  );
+}

--- a/application/frontend/client/proxy.ts
+++ b/application/frontend/client/proxy.ts
@@ -1,94 +1,16 @@
-import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { createServerClient } from "@supabase/ssr";
-import type { UserRoleType } from "@/const/type/auth/UserRoleType";
-
-// マイページ機能の認可は user_meta.role の allowlist（フェイルクローズ）で行う。
-// general / admin に厳密一致した場合のみ許可し、それ以外（common / null / 未知 / 取得失敗 / 例外）は全拒否する。
-const ALLOWED_ROLES: readonly UserRoleType[] = ["general", "admin"];
-
-// オープンリダイレクト予防のため、遷移先は内部固定パスのリテラルのみを使用する。
-const LOGIN_PATH = "/login";
-const MYPAGE_PATH = "/mypage";
+import { buildProxyContext } from "@/lib/proxy/context";
+import { resolveGuards } from "@/lib/proxy/routeGuards";
 
 export async function proxy(request: NextRequest) {
-  const response = NextResponse.next();
-  const pathname = request.nextUrl.pathname;
-  const isApiRoute = pathname.startsWith("/api/");
-  const isLoginPath = pathname === LOGIN_PATH;
-
-  // anon key 経由でセッション・role を検証する。Service Role Key は使用しない。
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll: () => request.cookies.getAll(),
-        setAll: (cookiesToSet) => {
-          cookiesToSet.forEach(({ name, value, options }) => {
-            response.cookies.set(name, value, options);
-          });
-        },
-      },
+  const ctx = await buildProxyContext(request);
+  for (const guard of resolveGuards(ctx.pathname)) {
+    const result = await guard(ctx);
+    if (result) {
+      return result;
     }
-  );
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  // 未認証
-  if (!user) {
-    if (isLoginPath) {
-      return response;
-    }
-    if (isApiRoute) {
-      return NextResponse.json(
-        { error: "認証が必要です", code: "UNAUTHORIZED" },
-        { status: 401 }
-      );
-    }
-    return NextResponse.redirect(new URL(LOGIN_PATH, request.url));
   }
-
-  // セッションあり → user_meta から role を取得（anon key・本人 RLS）。
-  // 取得失敗・例外も含めフェイルクローズで評価するため、role を文字列または null に正規化する。
-  let role: string | null = null;
-  try {
-    const { data: userMeta } = await supabase
-      .from("user_meta")
-      .select("role")
-      .eq("id", user.id)
-      .single<{ role: string | null }>();
-    role = userMeta?.role ?? null;
-  } catch {
-    role = null;
-  }
-
-  const allowed =
-    typeof role === "string" &&
-    (ALLOWED_ROLES as readonly string[]).includes(role);
-
-  // /login にセッションあり かつ 許可ロール → /mypage へ
-  if (isLoginPath) {
-    if (allowed) {
-      return NextResponse.redirect(new URL(MYPAGE_PATH, request.url));
-    }
-    return response;
-  }
-
-  // 保護対象（/mypage・client API）でロール許可外 → フェイルクローズ拒否
-  if (!allowed) {
-    if (isApiRoute) {
-      return NextResponse.json(
-        { error: "権限がありません", code: "FORBIDDEN" },
-        { status: 403 }
-      );
-    }
-    return NextResponse.redirect(new URL(LOGIN_PATH, request.url));
-  }
-
-  return response;
+  return ctx.response;
 }
 
 export const config = {


### PR DESCRIPTION
## 概要
Next 16 移行で `middleware.ts` → `proxy.ts` に改名した認証・認可ロジックを、今後ルートガードを追加しやすいよう **guard chain + route map** 構成に分割する。**挙動不変のリファクタ**。

Closes #63

## 方針
`proxy.ts` は薄いエントリ（`buildProxyContext` → `resolveGuards(pathname)` を順に実行、最初に `NextResponse` を返したガードで確定）。ロジックは `lib/proxy/` 配下へ分離。

```
proxy.ts                       # Next エントリ（function proxy + config.matcher）
lib/proxy/
  context.ts                   # ProxyContext + buildProxyContext()
  supabaseProxyClient.ts       # request/response 紐付け supabase server client（anon key）
  role.ts                      # user_meta から role 取得（client: fail-closed→null / admin: ??"common"）
  guards/types.ts              # Guard = (ctx) => NextResponse | null（null=次へ）
  guards/*.ts                  # 各ガード
  routeGuards.ts               # パス→ガード列の解決
```

- **client** ガード: `authGuard`（未認証 API401/他 /login）→ `roleGuard(["general","admin"])`（許可外 API403/他 /login）、`/login` は `loginRedirectGuard`（許可ロールなら /mypage）
- **admin** ガード: `authPublicGuard`（公開パス判定・未認証/認証済の振り分け）→ `adminRoleGuard`（admin 以外 API403/他 "/"、"/"は許可）

## 挙動維持の確認
- `config.matcher` は client / admin とも**従来と完全一致**。
- 旧 proxy.ts の全分岐（client の `/login` 特殊処理・フェイルクローズ、admin の publicPath・role デフォルト `"common"`・`/` 例外）を guard chain にそのままマッピング。role 取得回数も従来どおり最大 1 回。

## 検証
- `npx tsc --noEmit`: client / admin ともエラー 0（lint は環境都合で不使用）

## スコープ外
- room-tool。新規ガードの追加そのもの（土台のみ整備）。

## 備考
- 本 PR は #62（バージョン更新 + env 共通化 / `feature/E-61`）に**スタック**。#62 マージ後に base は自動で `main` に張り替わります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
