### PR TITLE
E-70 admin レベルキャップ変更画面の実装

### DIFF
--- a/application/frontend/admin/app/api/level-cap/route.ts
+++ b/application/frontend/admin/app/api/level-cap/route.ts
@@ -1,11 +1,39 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 import { createServerClient } from "@supabase/ssr";
+import type { LevelCapRowType } from "@/const/type/levelCap/LevelCapRowType";
 
 type ErrorResponse = {
   error: string;
   code: string;
 };
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+const INT4_MIN = -2147483648;
+const INT4_MAX = 2147483647;
+
+const REQUIRED_INTEGER_KEYS = [
+  "min_exp",
+  "min_reward",
+  "reward_amount",
+  "off_balance_reward",
+  "honor",
+  "growth_count",
+  "growth_limit",
+  "f_count_limit",
+  "reward_limit",
+] as const;
+
+const NULLABLE_INTEGER_KEYS = ["min_growth", "min_honor", "distribution", "exp_diff"] as const;
+
+const TEXT_KEYS = ["max_adventurer_rank", "reward_per_session", "sword_fragments", "excess_growth"] as const;
+
+type RequiredIntegerKey = (typeof REQUIRED_INTEGER_KEYS)[number];
+type NullableIntegerKey = (typeof NULLABLE_INTEGER_KEYS)[number];
+type TextKey = (typeof TEXT_KEYS)[number];
+
+type LevelCapUpdateFields = Partial<Pick<LevelCapRowType, RequiredIntegerKey | NullableIntegerKey | TextKey>>;
 
 const errorResponse = (error: string, code: string, status: number) =>
   NextResponse.json<ErrorResponse>({ error, code }, { status });
@@ -48,11 +76,94 @@ export async function GET(request: NextRequest) {
 
   const { data, error } = await supabaseAdmin
     .from("level_cap")
-    .select("id, level")
+    .select("*")
     .eq("belt_type", belt)
     .order("sort_order", { ascending: true });
 
   if (error) return errorResponse("データ取得に失敗しました", "INTERNAL_ERROR", 500);
 
-  return NextResponse.json(data as { id: number; level: string }[]);
+  return NextResponse.json((data ?? []) as LevelCapRowType[]);
+}
+
+export async function PUT(request: NextRequest) {
+  const user = await getAuthenticatedUser(request);
+  if (!user) return errorResponse("権限がありません", "FORBIDDEN", 403);
+
+  let body: JsonValue;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse("リクエストボディが不正です", "BAD_REQUEST", 400);
+  }
+
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return errorResponse("リクエストボディが不正です", "BAD_REQUEST", 400);
+  }
+
+  const items = body.items;
+  if (!Array.isArray(items)) {
+    return errorResponse("itemsが配列ではありません", "BAD_REQUEST", 400);
+  }
+
+  const updates: { id: number; fields: LevelCapUpdateFields }[] = [];
+
+  for (const item of items) {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) {
+      return errorResponse("itemsの要素が不正です", "BAD_REQUEST", 400);
+    }
+
+    const id = item.id;
+    if (typeof id !== "number" || !Number.isInteger(id) || id < INT4_MIN || id > INT4_MAX) {
+      return errorResponse("idが不正です", "BAD_REQUEST", 400);
+    }
+
+    const fields: LevelCapUpdateFields = {};
+
+    for (const [key, value] of Object.entries(item)) {
+      if (key === "id") continue;
+      if ((REQUIRED_INTEGER_KEYS as readonly string[]).includes(key)) {
+        if (typeof value !== "number" || !Number.isInteger(value)) {
+          return errorResponse(`整数ではありません: ${key}`, "BAD_REQUEST", 400);
+        }
+        if (value < INT4_MIN || value > INT4_MAX) {
+          return errorResponse(`整数の範囲外です: ${key}`, "BAD_REQUEST", 400);
+        }
+        fields[key as RequiredIntegerKey] = value;
+      } else if ((NULLABLE_INTEGER_KEYS as readonly string[]).includes(key)) {
+        if (value !== null && (typeof value !== "number" || !Number.isInteger(value))) {
+          return errorResponse(`整数またはnullではありません: ${key}`, "BAD_REQUEST", 400);
+        }
+        if (value !== null && (value < INT4_MIN || value > INT4_MAX)) {
+          return errorResponse(`整数の範囲外です: ${key}`, "BAD_REQUEST", 400);
+        }
+        fields[key as NullableIntegerKey] = value;
+      } else if ((TEXT_KEYS as readonly string[]).includes(key)) {
+        if (typeof value !== "string") {
+          return errorResponse(`値が文字列ではありません: ${key}`, "BAD_REQUEST", 400);
+        }
+        fields[key as TextKey] = value;
+      } else {
+        return errorResponse(`不正なキーです: ${key}`, "BAD_REQUEST", 400);
+      }
+    }
+
+    if (Object.keys(fields).length === 0) {
+      return errorResponse("更新対象のカラムがありません", "BAD_REQUEST", 400);
+    }
+
+    updates.push({ id, fields });
+  }
+
+  for (const update of updates) {
+    const { error } = await supabaseAdmin
+      .from("level_cap")
+      .update(update.fields)
+      .eq("id", update.id);
+
+    if (error) {
+      return errorResponse(`更新に失敗しました (id: ${update.id})`, "INTERNAL_ERROR", 500);
+    }
+  }
+
+  return NextResponse.json({ success: true });
 }

--- a/application/frontend/admin/app/level-cap/page.tsx
+++ b/application/frontend/admin/app/level-cap/page.tsx
@@ -1,0 +1,5 @@
+import LevelCapEditTemplate from "@/component/templates/LevelCapEditTemplate";
+
+export default function LevelCapPage() {
+  return <LevelCapEditTemplate />;
+}

--- a/application/frontend/admin/component/organisms/layout/Sidebar.tsx
+++ b/application/frontend/admin/component/organisms/layout/Sidebar.tsx
@@ -12,6 +12,7 @@ export default function Sidebar() {
   const MENU_ITEMS = [
     { label: "ダッシュボード", href: "/", adminOnly: false },
     { label: "基本情報変更", href: "/basic-info", adminOnly: true },
+    { label: "レベルキャップ変更", href: "/level-cap", adminOnly: true },
     { label: "レギュレーション管理", href: "/regulation", adminOnly: true },
     { label: "神格管理", href: "/god", adminOnly: true },
     { label: "流派管理", href: "/school", adminOnly: true },

--- a/application/frontend/admin/component/templates/LevelCapEditTemplate.tsx
+++ b/application/frontend/admin/component/templates/LevelCapEditTemplate.tsx
@@ -1,0 +1,191 @@
+"use client";
+import { Box, Heading, Button, HStack, Alert, Separator, Spinner, Tabs, Text, Table, Input, VStack } from "@chakra-ui/react";
+import { useState, useEffect } from "react";
+import AdminLayoutTemplate from "@/component/templates/AdminLayoutTemplate";
+import { useErrorHandler } from "@/hooks/useErrorHandler";
+import { levelCapConfig } from "@/const/config/levelCap";
+import { getLevelCaps } from "@/const/function/getLevelCaps";
+import { updateLevelCaps } from "@/const/function/updateLevelCaps";
+import { LEVEL_CAP_EDIT } from "@/const/pages/LEVEL_CAP_EDIT";
+import type { LevelCapFormRowType } from "@/const/type/levelCap/LevelCapFormRowType";
+import type { LevelCapSectionType } from "@/const/type/config/LevelCapConfigType";
+
+export default function LevelCapEditTemplate() {
+  const [rowsByBelt, setRowsByBelt] = useState<Record<string, LevelCapFormRowType[]>>({
+    [LEVEL_CAP_EDIT.VALUE.BELT_B]: [],
+    [LEVEL_CAP_EDIT.VALUE.BELT_C]: [],
+  });
+  const [belt, setBelt] = useState<string>(LEVEL_CAP_EDIT.VALUE.BELT_B);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isSaved, setIsSaved] = useState(false);
+  const { error, handleError, clearError } = useErrorHandler();
+
+  useEffect(() => {
+    const fetchLevelCaps = async () => {
+      try {
+        const [dataB, dataC] = await Promise.all([
+          getLevelCaps(LEVEL_CAP_EDIT.VALUE.BELT_B),
+          getLevelCaps(LEVEL_CAP_EDIT.VALUE.BELT_C),
+        ]);
+        setRowsByBelt({
+          [LEVEL_CAP_EDIT.VALUE.BELT_B]: levelCapConfig.toForm(dataB),
+          [LEVEL_CAP_EDIT.VALUE.BELT_C]: levelCapConfig.toForm(dataC),
+        });
+      } catch (err) {
+        handleError(err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchLevelCaps();
+  }, []);
+
+  const handleChange = (beltKey: string, rowId: number, column: string, value: string) => {
+    setRowsByBelt((prev) => ({
+      ...prev,
+      [beltKey]: (prev[beltKey] ?? []).map((row) =>
+        row.id === rowId ? { ...row, values: { ...row.values, [column]: value } } : row
+      ),
+    }));
+  };
+
+  const validate = (): string | null => {
+    const belts = [LEVEL_CAP_EDIT.VALUE.BELT_B, LEVEL_CAP_EDIT.VALUE.BELT_C];
+    for (const beltKey of belts) {
+      const beltLabel = beltKey === LEVEL_CAP_EDIT.VALUE.BELT_B ? LEVEL_CAP_EDIT.TEXT.TAB_B : LEVEL_CAP_EDIT.TEXT.TAB_C;
+      for (const row of rowsByBelt[beltKey] ?? []) {
+        for (const section of levelCapConfig.formSections) {
+          for (const field of section.fields) {
+            const value = (row.values[field.column] ?? "").trim();
+            const parsed = levelCapConfig.parseInteger(value);
+            if (field.valueType === "requiredInt") {
+              if (parsed === null) {
+                return `${beltLabel} ${LEVEL_CAP_EDIT.TEXT.LEVEL_PREFIX}${row.level} ${field.label}${LEVEL_CAP_EDIT.TEXT.ERROR_REQUIRED_INT}`;
+              }
+              if (Math.abs(parsed) > levelCapConfig.int4Max) {
+                return `${beltLabel} ${LEVEL_CAP_EDIT.TEXT.LEVEL_PREFIX}${row.level} ${field.label}${LEVEL_CAP_EDIT.TEXT.ERROR_INT_RANGE}`;
+              }
+            }
+            if (field.valueType === "nullableInt" && value !== "") {
+              if (parsed === null) {
+                return `${beltLabel} ${LEVEL_CAP_EDIT.TEXT.LEVEL_PREFIX}${row.level} ${field.label}${LEVEL_CAP_EDIT.TEXT.ERROR_NULLABLE_INT}`;
+              }
+              if (Math.abs(parsed) > levelCapConfig.int4Max) {
+                return `${beltLabel} ${LEVEL_CAP_EDIT.TEXT.LEVEL_PREFIX}${row.level} ${field.label}${LEVEL_CAP_EDIT.TEXT.ERROR_INT_RANGE}`;
+              }
+            }
+          }
+        }
+      }
+    }
+    return null;
+  };
+
+  const handleSave = async () => {
+    clearError();
+    setIsSaved(false);
+    const validationError = validate();
+    if (validationError) {
+      handleError(new Error(validationError));
+      return;
+    }
+    setIsSaving(true);
+    try {
+      const allRows = [
+        ...(rowsByBelt[LEVEL_CAP_EDIT.VALUE.BELT_B] ?? []),
+        ...(rowsByBelt[LEVEL_CAP_EDIT.VALUE.BELT_C] ?? []),
+      ];
+      await updateLevelCaps(levelCapConfig.toBody(allRows));
+      setIsSaved(true);
+    } catch (err) {
+      handleError(err);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const renderSectionTable = (beltKey: string, rows: LevelCapFormRowType[], section: LevelCapSectionType) => (
+    <Box key={section.title} minWidth="0">
+      <Text fontWeight="bold" fontSize="md" mb={2}>{section.title}</Text>
+      <Box width="100%" minWidth="0" borderWidth="1px" borderRadius="md" overflowX="auto">
+        <Table.Root size="sm">
+          <Table.Header>
+            <Table.Row>
+              <Table.ColumnHeader whiteSpace="nowrap">{LEVEL_CAP_EDIT.TEXT.LEVEL_PREFIX}</Table.ColumnHeader>
+              {section.fields.map((field) => (
+                <Table.ColumnHeader key={field.column} whiteSpace="nowrap">
+                  {field.label}
+                </Table.ColumnHeader>
+              ))}
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {rows.map((row) => (
+              <Table.Row key={`${beltKey}-${row.id}`}>
+                <Table.Cell whiteSpace="nowrap" fontWeight="bold">{row.level}</Table.Cell>
+                {section.fields.map((field) => (
+                  <Table.Cell key={field.column} minW={field.valueType === "text" ? "9rem" : "7rem"}>
+                    <Input
+                      size="sm"
+                      value={row.values[field.column] ?? ""}
+                      onChange={(e) => handleChange(beltKey, row.id, field.column, e.target.value)}
+                    />
+                  </Table.Cell>
+                ))}
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table.Root>
+      </Box>
+      {section.footnote && (
+        <Text fontSize="xs" color="gray.500" mt={1}>{section.footnote}</Text>
+      )}
+    </Box>
+  );
+
+  return (
+    <AdminLayoutTemplate title={LEVEL_CAP_EDIT.TEXT.TITLE}>
+      <Heading size="md" mb={4}>{LEVEL_CAP_EDIT.TEXT.TITLE}</Heading>
+      <Box bg="white" borderRadius="md" shadow="sm" p={6}>
+        {error && (
+          <Alert.Root status="error" mb={4}>
+            <Alert.Indicator />
+            <Alert.Description>{error}</Alert.Description>
+          </Alert.Root>
+        )}
+        {isSaved && (
+          <Alert.Root status="success" mb={4}>
+            <Alert.Indicator />
+            <Alert.Description>{LEVEL_CAP_EDIT.TEXT.SAVED}</Alert.Description>
+          </Alert.Root>
+        )}
+        {isLoading ? (
+          <Spinner />
+        ) : (
+          <>
+            <Tabs.Root value={belt} onValueChange={(details) => setBelt(details.value)} mb={4}>
+              <Tabs.List>
+                <Tabs.Trigger value={LEVEL_CAP_EDIT.VALUE.BELT_B} cursor="pointer">
+                  {LEVEL_CAP_EDIT.TEXT.TAB_B}
+                </Tabs.Trigger>
+                <Tabs.Trigger value={LEVEL_CAP_EDIT.VALUE.BELT_C} cursor="pointer">
+                  {LEVEL_CAP_EDIT.TEXT.TAB_C}
+                </Tabs.Trigger>
+              </Tabs.List>
+            </Tabs.Root>
+            <VStack gap={8} align="stretch">
+              {levelCapConfig.formSections.map((section) => renderSectionTable(belt, rowsByBelt[belt] ?? [], section))}
+            </VStack>
+            <Separator mt={8} mb={4} />
+            <HStack justify="flex-end">
+              <Button colorPalette="blue" onClick={handleSave} loading={isSaving}>
+                {LEVEL_CAP_EDIT.TEXT.SAVE}
+              </Button>
+            </HStack>
+          </>
+        )}
+      </Box>
+    </AdminLayoutTemplate>
+  );
+}

--- a/application/frontend/admin/const/config/levelCap.ts
+++ b/application/frontend/admin/const/config/levelCap.ts
@@ -1,0 +1,88 @@
+import { LEVEL_CAP_EDIT } from "@/const/pages/LEVEL_CAP_EDIT";
+import type { LevelCapConfigType } from "@/const/type/config/LevelCapConfigType";
+
+export const levelCapConfig: LevelCapConfigType = {
+  formSections: [
+    {
+      title: LEVEL_CAP_EDIT.TEXT.SECTION_PROCESS,
+      fields: [
+        { column: "minExp", label: LEVEL_CAP_EDIT.TEXT.LABEL_MIN_EXP, valueType: "requiredInt" },
+        { column: "expDiff", label: LEVEL_CAP_EDIT.TEXT.LABEL_EXP_DIFF, valueType: "nullableInt" },
+        { column: "minGrowth", label: LEVEL_CAP_EDIT.TEXT.LABEL_MIN_GROWTH, valueType: "nullableInt" },
+        { column: "minReward", label: LEVEL_CAP_EDIT.TEXT.LABEL_MIN_REWARD, valueType: "requiredInt" },
+        { column: "minHonor", label: LEVEL_CAP_EDIT.TEXT.LABEL_MIN_HONOR, valueType: "nullableInt" },
+        { column: "maxAdventurerRank", label: LEVEL_CAP_EDIT.TEXT.LABEL_MAX_ADVENTURER_RANK, valueType: "text" },
+      ],
+      footnote: LEVEL_CAP_EDIT.TEXT.NOTE_EXP_DIFF,
+    },
+    {
+      title: LEVEL_CAP_EDIT.TEXT.SECTION_GM_REWARD,
+      fields: [
+        { column: "rewardAmount", label: LEVEL_CAP_EDIT.TEXT.LABEL_REWARD_AMOUNT, valueType: "requiredInt" },
+        { column: "offBalanceReward", label: LEVEL_CAP_EDIT.TEXT.LABEL_OFF_BALANCE_REWARD, valueType: "requiredInt" },
+        { column: "honor", label: LEVEL_CAP_EDIT.TEXT.LABEL_HONOR, valueType: "requiredInt" },
+      ],
+    },
+    {
+      title: LEVEL_CAP_EDIT.TEXT.SECTION_SESSION_REWARD,
+      fields: [
+        { column: "distribution", label: LEVEL_CAP_EDIT.TEXT.LABEL_DISTRIBUTION, valueType: "nullableInt" },
+        { column: "rewardPerSession", label: LEVEL_CAP_EDIT.TEXT.LABEL_REWARD_PER_SESSION, valueType: "text" },
+        { column: "swordFragments", label: LEVEL_CAP_EDIT.TEXT.LABEL_SWORD_FRAGMENTS, valueType: "text" },
+        { column: "growthCount", label: LEVEL_CAP_EDIT.TEXT.LABEL_GROWTH_COUNT, valueType: "requiredInt" },
+        { column: "growthLimit", label: LEVEL_CAP_EDIT.TEXT.LABEL_GROWTH_LIMIT, valueType: "requiredInt" },
+        { column: "fCountLimit", label: LEVEL_CAP_EDIT.TEXT.LABEL_F_COUNT_LIMIT, valueType: "requiredInt" },
+        { column: "rewardLimit", label: LEVEL_CAP_EDIT.TEXT.LABEL_REWARD_LIMIT, valueType: "requiredInt" },
+        { column: "excessGrowth", label: LEVEL_CAP_EDIT.TEXT.LABEL_EXCESS_GROWTH, valueType: "text" },
+      ],
+    },
+  ],
+  int4Max: 2147483647,
+  parseInteger: (text) => (/^-?\d+$/.test(text.trim()) ? Number(text.trim()) : null),
+  toForm: (rows) =>
+    rows.map((row) => ({
+      id: row.id,
+      level: row.level,
+      values: {
+        minExp: String(row.min_exp),
+        expDiff: row.exp_diff !== null ? String(row.exp_diff) : "",
+        minGrowth: row.min_growth !== null ? String(row.min_growth) : "",
+        minReward: String(row.min_reward),
+        minHonor: row.min_honor !== null ? String(row.min_honor) : "",
+        maxAdventurerRank: row.max_adventurer_rank,
+        rewardAmount: String(row.reward_amount),
+        offBalanceReward: String(row.off_balance_reward),
+        honor: String(row.honor),
+        distribution: row.distribution !== null ? String(row.distribution) : "",
+        rewardPerSession: row.reward_per_session,
+        swordFragments: row.sword_fragments,
+        growthCount: String(row.growth_count),
+        growthLimit: String(row.growth_limit),
+        fCountLimit: String(row.f_count_limit),
+        rewardLimit: String(row.reward_limit),
+        excessGrowth: row.excess_growth,
+      },
+    })),
+  toBody: (rows) => ({
+    items: rows.map((row) => ({
+      id: row.id,
+      min_exp: Number(row.values.minExp?.trim()),
+      min_growth: row.values.minGrowth?.trim() ? Number(row.values.minGrowth.trim()) : null,
+      min_reward: Number(row.values.minReward?.trim()),
+      min_honor: row.values.minHonor?.trim() ? Number(row.values.minHonor.trim()) : null,
+      exp_diff: row.values.expDiff?.trim() ? Number(row.values.expDiff.trim()) : null,
+      max_adventurer_rank: (row.values.maxAdventurerRank ?? "").trim(),
+      reward_amount: Number(row.values.rewardAmount?.trim()),
+      off_balance_reward: Number(row.values.offBalanceReward?.trim()),
+      honor: Number(row.values.honor?.trim()),
+      distribution: row.values.distribution?.trim() ? Number(row.values.distribution.trim()) : null,
+      reward_per_session: (row.values.rewardPerSession ?? "").trim(),
+      sword_fragments: (row.values.swordFragments ?? "").trim(),
+      growth_count: Number(row.values.growthCount?.trim()),
+      growth_limit: Number(row.values.growthLimit?.trim()),
+      f_count_limit: Number(row.values.fCountLimit?.trim()),
+      reward_limit: Number(row.values.rewardLimit?.trim()),
+      excess_growth: (row.values.excessGrowth ?? "").trim(),
+    })),
+  }),
+};

--- a/application/frontend/admin/const/function/getLevelCaps.ts
+++ b/application/frontend/admin/const/function/getLevelCaps.ts
@@ -1,0 +1,10 @@
+import type { LevelCapRowType } from "@/const/type/levelCap/LevelCapRowType";
+
+export const getLevelCaps = async (belt: string): Promise<LevelCapRowType[]> => {
+  const res = await fetch(`/api/level-cap?belt=${belt}`, { cache: "no-store" });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: "" })) as { error: string };
+    throw new Error(body.error || "データ取得に失敗しました");
+  }
+  return res.json() as Promise<LevelCapRowType[]>;
+};

--- a/application/frontend/admin/const/function/updateLevelCaps.ts
+++ b/application/frontend/admin/const/function/updateLevelCaps.ts
@@ -1,0 +1,13 @@
+import type { LevelCapUpdateItemType } from "@/const/type/levelCap/LevelCapUpdateItemType";
+
+export const updateLevelCaps = async (body: { items: LevelCapUpdateItemType[] }): Promise<void> => {
+  const res = await fetch("/api/level-cap", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const resBody = await res.json().catch(() => ({ error: "" })) as { error: string };
+    throw new Error(resBody.error || "更新に失敗しました");
+  }
+};

--- a/application/frontend/admin/const/pages/LEVEL_CAP_EDIT.tsx
+++ b/application/frontend/admin/const/pages/LEVEL_CAP_EDIT.tsx
@@ -1,0 +1,41 @@
+export const LEVEL_CAP_EDIT: {
+  TEXT: { [key: string]: string };
+  VALUE: { [key: string]: string };
+} = {
+  TEXT: {
+    TITLE: "レベルキャップ変更",
+    SAVE: "保存",
+    SAVED: "保存しました。閲覧サイトへ反映するにはダッシュボードの「変更を反映」を実行してください。",
+    TAB_B: "レベルキャップ B",
+    TAB_C: "レベルキャップ C",
+    SECTION_PROCESS: "レベルキャップ処理",
+    SECTION_GM_REWARD: "GM報酬",
+    SECTION_SESSION_REWARD: "セッション報酬",
+    LABEL_MIN_EXP: "下限Exp.(点)",
+    LABEL_EXP_DIFF: "Exp.差分(点)",
+    NOTE_EXP_DIFF: "※Exp.差分(点)は自動計算されません。下限Exp.(点)を変更した場合は手動で更新してください。",
+    LABEL_MIN_GROWTH: "下限成長(回)",
+    LABEL_MIN_REWARD: "下限報酬(G)",
+    LABEL_MIN_HONOR: "下限名誉(点)",
+    LABEL_MAX_ADVENTURER_RANK: "上限冒険者ランク",
+    LABEL_REWARD_AMOUNT: "報酬金額",
+    LABEL_OFF_BALANCE_REWARD: "収支外報酬",
+    LABEL_HONOR: "名誉点",
+    LABEL_DISTRIBUTION: "配給",
+    LABEL_REWARD_PER_SESSION: "1卓の報酬目安",
+    LABEL_SWORD_FRAGMENTS: "剣の欠片目安",
+    LABEL_GROWTH_COUNT: "成長回数",
+    LABEL_GROWTH_LIMIT: "成長上限",
+    LABEL_F_COUNT_LIMIT: "F回数上限",
+    LABEL_REWARD_LIMIT: "報酬上限",
+    LABEL_EXCESS_GROWTH: "超過成長(1/4)",
+    LEVEL_PREFIX: "Lv.",
+    ERROR_REQUIRED_INT: "は整数で入力してください",
+    ERROR_NULLABLE_INT: "は空欄または整数で入力してください",
+    ERROR_INT_RANGE: "は-2147483647〜2147483647の範囲で入力してください",
+  },
+  VALUE: {
+    BELT_B: "B",
+    BELT_C: "C",
+  },
+} as const;

--- a/application/frontend/admin/const/type/config/LevelCapConfigType.ts
+++ b/application/frontend/admin/const/type/config/LevelCapConfigType.ts
@@ -1,0 +1,25 @@
+import type { LevelCapRowType } from "@/const/type/levelCap/LevelCapRowType";
+import type { LevelCapFormRowType } from "@/const/type/levelCap/LevelCapFormRowType";
+import type { LevelCapUpdateItemType } from "@/const/type/levelCap/LevelCapUpdateItemType";
+
+export type LevelCapFieldValueType = "requiredInt" | "nullableInt" | "text";
+
+export type LevelCapFieldType = {
+  column: string;
+  label: string;
+  valueType: LevelCapFieldValueType;
+};
+
+export type LevelCapSectionType = {
+  title: string;
+  fields: LevelCapFieldType[];
+  footnote?: string;
+};
+
+export type LevelCapConfigType = {
+  formSections: LevelCapSectionType[];
+  int4Max: number;
+  parseInteger: (text: string) => number | null;
+  toForm: (rows: LevelCapRowType[]) => LevelCapFormRowType[];
+  toBody: (rows: LevelCapFormRowType[]) => { items: LevelCapUpdateItemType[] };
+};

--- a/application/frontend/admin/const/type/levelCap/LevelCapFormRowType.ts
+++ b/application/frontend/admin/const/type/levelCap/LevelCapFormRowType.ts
@@ -1,0 +1,5 @@
+export type LevelCapFormRowType = {
+  id: number;
+  level: string;
+  values: Record<string, string>;
+};

--- a/application/frontend/admin/const/type/levelCap/LevelCapRowType.ts
+++ b/application/frontend/admin/const/type/levelCap/LevelCapRowType.ts
@@ -1,0 +1,23 @@
+export type LevelCapRowType = {
+  id: number;
+  belt_type: string;
+  level: string;
+  sort_order: number;
+  min_exp: number;
+  min_growth: number | null;
+  min_reward: number;
+  min_honor: number | null;
+  exp_diff: number | null;
+  max_adventurer_rank: string;
+  reward_amount: number;
+  off_balance_reward: number;
+  honor: number;
+  distribution: number | null;
+  reward_per_session: string;
+  sword_fragments: string;
+  growth_count: number;
+  growth_limit: number;
+  f_count_limit: number;
+  reward_limit: number;
+  excess_growth: string;
+};

--- a/application/frontend/admin/const/type/levelCap/LevelCapUpdateItemType.ts
+++ b/application/frontend/admin/const/type/levelCap/LevelCapUpdateItemType.ts
@@ -1,0 +1,20 @@
+export type LevelCapUpdateItemType = {
+  id: number;
+  min_exp: number;
+  min_growth: number | null;
+  min_reward: number;
+  min_honor: number | null;
+  exp_diff: number | null;
+  max_adventurer_rank: string;
+  reward_amount: number;
+  off_balance_reward: number;
+  honor: number;
+  distribution: number | null;
+  reward_per_session: string;
+  sword_fragments: string;
+  growth_count: number;
+  growth_limit: number;
+  f_count_limit: number;
+  reward_limit: number;
+  excess_growth: string;
+};


### PR DESCRIPTION
## Summary
- admin に「レベルキャップ変更」画面（/level-cap）を追加。client の閲覧画面と同じ 3 テーブル構成（レベルキャップ処理／GM報酬／セッション報酬）で、B/C ベルトをタブ切替してセル単位で編集できる
- level-cap API を拡張: GET を全カラム返却に変更（既存利用箇所とは後方互換）、編集 17 カラムをホワイトリスト検証（整数・int4 範囲・null 許可）して行ごとに更新する PUT を新設
- サイドバーに「レベルキャップ変更」メニューを追加。文言・型・config は既存の basic-info（E-68）と同じパターンで構成

## Issue
Close #70

## Test plan
- [ ] admin にログインし、サイドバーの「レベルキャップ変更」から /level-cap を開ける
- [ ] B/C タブ切替で各ベルトのレベル行が表示され、切替しても入力値が保持される
- [ ] 数値項目に不正値（空欄・非整数・int4 範囲外）を入れて保存するとエラー表示され、PUT されない
- [ ] 正常値で保存 → 成功メッセージ表示 → 「変更を反映」後に client のレベルキャップ表へ反映される
- [ ] 非 admin ユーザーで /api/level-cap の GET/PUT が 403 になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)